### PR TITLE
Add support for accumulated fields and fill values; clean-up

### DIFF
--- a/src/hist_api.F90
+++ b/src/hist_api.F90
@@ -1,10 +1,6 @@
 module hist_api
 
-   use ISO_FORTRAN_ENV, only: REAL64, REAL32, INT32, INT64
-   use hist_buffer,     only: hist_buff_1dreal32_t
-   use hist_buffer,     only: hist_buff_1dreal64_t
-   use hist_buffer,     only: hist_buff_2dreal32_t
-   use hist_buffer,     only: hist_buff_2dreal64_t
+   use ISO_FORTRAN_ENV, only: REAL64, INT32, INT64
 
    implicit none
    private
@@ -18,24 +14,18 @@ module hist_api
 
    ! Interfaces for public interfaces
    interface hist_field_accumulate
-      module procedure hist_field_accumulate_1d_REAL32
-      module procedure hist_field_accumulate_1d_REAL64
-      module procedure hist_field_accumulate_2d_REAL32
-      module procedure hist_field_accumulate_2d_REAL64
+      module procedure hist_field_accumulate_1d
+      module procedure hist_field_accumulate_2d
    end interface hist_field_accumulate
 
    interface hist_buffer_accumulate
-      module procedure hist_buffer_accumulate_1d_REAL32
-      module procedure hist_buffer_accumulate_1d_REAL64
-      module procedure hist_buffer_accumulate_2d_REAL32
-      module procedure hist_buffer_accumulate_2d_REAL64
+      module procedure hist_buffer_accumulate_1d
+      module procedure hist_buffer_accumulate_2d
    end interface hist_buffer_accumulate
 
    interface hist_buffer_norm_value
-      module procedure hist_buffer_norm_value_1dreal32
-      module procedure hist_buffer_norm_value_1dreal64
-      module procedure hist_buffer_norm_value_2dreal32
-      module procedure hist_buffer_norm_value_2dreal64
+      module procedure hist_buffer_norm_value_1d
+      module procedure hist_buffer_norm_value_2d
    end interface hist_buffer_norm_value
 
 CONTAINS
@@ -150,34 +140,6 @@ CONTAINS
       else
          type_str = 'unknown'
       end if
-      select case (type_str)
-      case ('integer')
-         select case (buff_kind)
-         case (INT32)
-            kind_string = 'int32'
-         case (INT64)
-            kind_string = 'int64'
-         case default
-            kind_string = ''
-         end select
-      case ('real')
-         select case(buff_kind)
-         case (REAL32)
-            kind_string = 'real32'
-         case (REAL64)
-            kind_string = 'real64'
-         case default
-            kind_string = ''
-         end select
-      case default
-         kind_string = ''
-         call hist_add_error(subname, "type, '"//type_str,                    &
-              errstr2="' is not supported", errors=errors)
-      end select
-      if ((len_trim(kind_string) == 0) .and. present(errors)) then
-         call errors%new_error("kind = ", errint1=buff_kind,                  &
-              errstr2=" is not supported for type "//type_str, subname=subname)
-      end if
       ! Check horiz_axis_ind
       if ((horiz_axis_ind < 1) .or. (horiz_axis_ind > rank)) then
          call hist_add_error(subname, 'horiz_axis_ind outside of ',           &
@@ -224,22 +186,12 @@ CONTAINS
               errstr2=trim(accum_type)//"'", errors=errors)
       end select
       ! We now know what sort of buffer we need
-      ! First, sort by rank
+      ! Based on rank
       select case (rank)
       case (1)
-         ! sort by kind (already checked above)
-         if (buff_kind == REAL32) then
-            bufftype_string = 'real32_1'
-         else if (buff_kind == REAL64) then
-            bufftype_string = 'real64_1'
-         end if
+         bufftype_string = 'real_1'
       case (2)
-         ! sort by kind
-         if (buff_kind == REAL32) then
-            bufftype_string = 'real32_2'
-         else if (buff_kind == REAL64) then
-            bufftype_string = 'real64_2'
-         end if
+         bufftype_string = 'real_2'
       case default
          ! Over max rank currently handled
          call hist_add_error(subname, 'buffers have a max rank of ',          &
@@ -282,54 +234,7 @@ CONTAINS
 
    !#######################################################################
 
-   subroutine hist_field_accumulate_1d_REAL32(field, data, cols_or_block,      &
-        cole, logger)
-      use hist_msg_handler, only: hist_log_messages, hist_have_error, ERROR
-      use hist_msg_handler, only: hist_add_message, VERBOSE
-      use hist_field,       only: hist_field_info_t
-      use hist_buffer,      only: hist_buffer_t
-
-      ! Dummy arguments
-      class(hist_field_info_t), pointer,  intent(inout) :: field
-      real(REAL32),                       intent(in)    :: data(:)
-      integer,                            intent(in)    :: cols_or_block
-      integer,                  optional, intent(in)    :: cole
-      type(hist_log_messages),  optional, intent(inout) :: logger
-      ! Local variables
-      class(hist_buffer_t), pointer     :: buff_ptr
-      character(len=:),     allocatable :: buff_typestr
-      character(len=*), parameter :: subname = 'hist_field_accumulate_1d_REAL32'
-
-      if (associated(field)) then
-         buff_ptr => field%buffers
-         do
-            if (associated(buff_ptr) .and.                                    &
-                 (.not. hist_have_error(errors=logger))) then
-               call hist_buffer_accumulate(buff_ptr, data, cols_or_block,     &
-                    cole=cole, logger=logger)
-               if (hist_have_error(errors=logger)) then
-                  call  logger%add_stack_frame(ERROR, __FILE__, __LINE__ - 3, &
-                       subname=subname)
-                  exit
-               else
-                  call hist_add_message(subname, VERBOSE,                     &
-                       "Accumulated data for",                                &
-                       msgstr2=trim(field%diag_name())//", Buffer type, ",    &
-                       msgstr3=trim(buff_ptr%buffer_type()),                  &
-                       logger=logger)
-                  buff_ptr => buff_ptr%next
-               end if
-            else
-               exit
-            end if
-         end do
-      end if ! No else, it is legit to pass in a null pointer
-
-   end subroutine hist_field_accumulate_1d_REAL32
-
-   !#######################################################################
-
-   subroutine hist_field_accumulate_1d_REAL64(field, data, cols_or_block,      &
+   subroutine hist_field_accumulate_1d(field, data, cols_or_block,      &
         cole, logger)
       use hist_msg_handler, only: hist_log_messages, hist_have_error, ERROR
       use hist_msg_handler, only: hist_add_message, VERBOSE
@@ -344,8 +249,7 @@ CONTAINS
       type(hist_log_messages),  optional, intent(inout) :: logger
       ! Local variables
       class(hist_buffer_t), pointer     :: buff_ptr
-      character(len=:),     allocatable :: buff_typestr
-      character(len=*), parameter :: subname = 'hist_field_accumulate_1d_REAL64'
+      character(len=*), parameter :: subname = 'hist_field_accumulate_1d'
 
       if (associated(field)) then
          buff_ptr => field%buffers
@@ -372,58 +276,11 @@ CONTAINS
          end do
       end if ! No else, it is legit to pass in a null pointer
 
-   end subroutine hist_field_accumulate_1d_REAL64
+   end subroutine hist_field_accumulate_1d
 
    !#######################################################################
 
-   subroutine hist_field_accumulate_2d_REAL32(field, data, cols_or_block,      &
-        cole, logger)
-      use hist_msg_handler, only: hist_log_messages, hist_have_error, ERROR
-      use hist_msg_handler, only: hist_add_message, VERBOSE
-      use hist_field,       only: hist_field_info_t
-      use hist_buffer,      only: hist_buffer_t
-
-      ! Dummy arguments
-      class(hist_field_info_t), pointer,  intent(inout) :: field
-      real(REAL32),                       intent(in)    :: data(:,:)
-      integer,                            intent(in)    :: cols_or_block
-      integer,                  optional, intent(in)    :: cole
-      type(hist_log_messages),  optional, intent(inout) :: logger
-      ! Local variables
-      class(hist_buffer_t), pointer     :: buff_ptr
-      character(len=:),     allocatable :: buff_typestr
-      character(len=*),     parameter   :: subname = 'hist_field_accumulate_2d_REAL32'
-
-      if (associated(field)) then
-         buff_ptr => field%buffers
-         do
-            if (associated(buff_ptr) .and.                                    &
-                 (.not. hist_have_error(errors=logger))) then
-               call hist_buffer_accumulate(buff_ptr, data, cols_or_block,     &
-                    cole=cole, logger=logger)
-               if (hist_have_error(errors=logger)) then
-                  call  logger%add_stack_frame(ERROR, __FILE__, __LINE__ - 3, &
-                       subname=subname)
-                  exit
-               else
-                  call hist_add_message(subname, VERBOSE,                     &
-                       "Accumulated data for",                                &
-                       msgstr2=trim(field%diag_name())//", Buffer type, ",    &
-                       msgstr3=trim(buff_ptr%buffer_type()),                  &
-                       logger=logger)
-                  buff_ptr => buff_ptr%next
-               end if
-            else
-               exit
-            end if
-         end do
-      end if ! No else, it is legit to pass in a null pointer
-
-   end subroutine hist_field_accumulate_2d_REAL32
-
-   !#######################################################################
-
-   subroutine hist_field_accumulate_2d_REAL64(field, data, cols_or_block,      &
+   subroutine hist_field_accumulate_2d(field, data, cols_or_block,      &
         cole, logger)
       use hist_msg_handler, only: hist_log_messages, hist_have_error, ERROR
       use hist_msg_handler, only: hist_add_message, VERBOSE
@@ -438,8 +295,7 @@ CONTAINS
       type(hist_log_messages),  optional, intent(inout) :: logger
       ! Local variables
       class(hist_buffer_t), pointer     :: buff_ptr
-      character(len=:),     allocatable :: buff_typestr
-      character(len=*),     parameter   :: subname = 'hist_field_accumulate_2d_REAL64'
+      character(len=*),     parameter   :: subname = 'hist_field_accumulate_2d'
 
       if (associated(field)) then
          buff_ptr => field%buffers
@@ -466,50 +322,14 @@ CONTAINS
          end do
       end if ! No else, it is legit to pass in a null pointer
 
-   end subroutine hist_field_accumulate_2d_REAL64
+   end subroutine hist_field_accumulate_2d
 
    !#######################################################################
 
-   subroutine hist_buffer_accumulate_1d_REAL32(buffer, field, cols_or_block,   &
+   subroutine hist_buffer_accumulate_1d(buffer, field, cols_or_block,   &
         cole, logger)
-      use hist_msg_handler, only: hist_log_messages, hist_add_error
-      use hist_buffer,      only: hist_buffer_t
-
-      ! Dummy arguments
-      class(hist_buffer_t),    target,   intent(inout) :: buffer
-      real(REAL32),                      intent(in)    :: field(:)
-      integer,                           intent(in)    :: cols_or_block
-      integer,                 optional, intent(in)    :: cole
-      type(hist_log_messages), optional, intent(inout) :: logger
-      ! Local variables
-      class(hist_buff_1dreal32_t), pointer          :: buff32
-      class(hist_buff_1dreal64_t), pointer          :: buff64
-      character(len=:),                 allocatable :: buff_typestr
-      character(len=*), parameter :: subname = 'hist_buffer_accumulate_1d_REAL32'
-
-      select type(buffer)
-      class is (hist_buff_1dreal32_t)
-         buff32 => buffer
-         call buff32%accumulate(field, cols_or_block, cole, logger)
-      class is (hist_buff_1dreal64_t)
-         ! Do we want to accumulate 32bit data into 64bit buffers?
-         buff64 => buffer
-         call buff64%accumulate(real(field, REAL64), cols_or_block, cole,     &
-              logger)
-      class default
-         buff_typestr = buffer%buffer_type()
-         call hist_add_error(subname, "unsupported buffer type, '",           &
-              errstr2=buff_typestr, errstr3="'", errors=logger)
-      end select
-
-   end subroutine hist_buffer_accumulate_1d_REAL32
-
-   !#######################################################################
-
-   subroutine hist_buffer_accumulate_1d_REAL64(buffer, field, cols_or_block,   &
-        cole, logger)
-      use hist_msg_handler, only: hist_log_messages, hist_add_error
-      use hist_buffer,      only: hist_buffer_t
+      use hist_buffer,      only: hist_buffer_t, hist_buff_1d_t
+      use hist_msg_handler, only: hist_log_messages
 
       ! Dummy arguments
       class(hist_buffer_t),    target,   intent(inout) :: buffer
@@ -517,67 +337,23 @@ CONTAINS
       integer,                           intent(in)    :: cols_or_block
       integer,                 optional, intent(in)    :: cole
       type(hist_log_messages), optional, intent(inout) :: logger
-      ! Local variables
-      class(hist_buff_1dreal32_t), pointer          :: buff32
-      class(hist_buff_1dreal64_t), pointer          :: buff64
-      character(len=:),                 allocatable :: buff_typestr
-      character(len=*), parameter :: subname = 'hist_buffer_accumulate_1d_REAL64'
+      ! Local variable
+      class(hist_buff_1d_t), pointer :: buff
 
-      select type(buffer)
-      class is (hist_buff_1dreal32_t)
-         buff32 => buffer
-         call buff32%accumulate(real(field, REAL32), cols_or_block, cole, logger)
-      class is (hist_buff_1dreal64_t)
-         buff64 => buffer
-         call buff64%accumulate(field, cols_or_block, cole, logger)
-      class default
-         buff_typestr = buffer%buffer_type()
-         call hist_add_error(subname, "unsupported buffer type, '",           &
-              errstr2=buff_typestr, errstr3="'", errors=logger)
+      select type (buffer)
+      class is (hist_buff_1d_t)
+         buff => buffer
+         call buff%accumulate(field, cols_or_block, cole, logger)
       end select
 
-   end subroutine hist_buffer_accumulate_1d_REAL64
+   end subroutine hist_buffer_accumulate_1d
 
    !#######################################################################
 
-   subroutine hist_buffer_accumulate_2d_REAL32(buffer, field, cols_or_block,   &
+   subroutine hist_buffer_accumulate_2d(buffer, field, cols_or_block,   &
         cole, logger)
-      use hist_msg_handler, only: hist_log_messages, hist_add_error
-      use hist_buffer,      only: hist_buffer_t
-
-      ! Dummy arguments
-      class(hist_buffer_t),    target,   intent(inout) :: buffer
-      real(REAL32),                      intent(in)    :: field(:,:)
-      integer,                           intent(in)    :: cols_or_block
-      integer,                 optional, intent(in)    :: cole
-      type(hist_log_messages), optional, intent(inout) :: logger
-      ! Local variables
-      type(hist_buff_2dreal32_t), pointer          :: buff32
-      type(hist_buff_2dreal64_t), pointer          :: buff64
-      character(len=:),                allocatable :: buff_typestr
-      character(len=*), parameter :: subname = 'hist_buffer_accumulate_2d_REAL32'
-
-      select type(buffer)
-      class is (hist_buff_2dreal32_t)
-         buff32 => buffer
-         call buff32%accumulate(field, cols_or_block, cole, logger)
-      class is (hist_buff_2dreal64_t)
-         buff64 => buffer
-         call buff64%accumulate(real(field, REAL64), cols_or_block, cole, logger)
-      class default
-         buff_typestr = buffer%buffer_type()
-         call hist_add_error(subname, "unsupported buffer type, '",           &
-              errstr2=buff_typestr, errstr3="'", errors=logger)
-      end select
-
-   end subroutine hist_buffer_accumulate_2d_REAL32
-
-   !#######################################################################
-
-   subroutine hist_buffer_accumulate_2d_REAL64(buffer, field, cols_or_block,   &
-        cole, logger)
-      use hist_msg_handler, only: hist_log_messages, hist_add_error
-      use hist_buffer,      only: hist_buffer_t
+      use hist_buffer,      only: hist_buffer_t, hist_buff_2d_t
+      use hist_msg_handler, only: hist_log_messages
 
       ! Dummy arguments
       class(hist_buffer_t),    target,   intent(inout) :: buffer
@@ -585,165 +361,57 @@ CONTAINS
       integer,                           intent(in)    :: cols_or_block
       integer,                 optional, intent(in)    :: cole
       type(hist_log_messages), optional, intent(inout) :: logger
-      ! Local variables
-      type(hist_buff_2dreal32_t), pointer          :: buff32
-      type(hist_buff_2dreal64_t), pointer          :: buff64
-      character(len=:),                allocatable :: buff_typestr
-      character(len=*), parameter :: subname = 'hist_buffer_accumulate_2d_REAL64'
+      ! Local variable
+      class(hist_buff_2d_t), pointer :: buff
 
-      select type(buffer)
-      class is (hist_buff_2dreal32_t)
-         buff32 => buffer
-         call buff32%accumulate(real(field, REAL32), cols_or_block, cole, logger)
-      class is (hist_buff_2dreal64_t)
-         buff64 => buffer
-         call buff64%accumulate(field, cols_or_block, cole, logger)
-      class default
-         buff_typestr = buffer%buffer_type()
-         call hist_add_error(subname, "unsupported buffer type, '",           &
-              errstr2=buff_typestr, errstr3="'", errors=logger)
+      select type (buffer)
+      class is (hist_buff_2d_t)
+         buff => buffer
+         call buff%accumulate(field, cols_or_block, cole, logger)
       end select
 
-   end subroutine hist_buffer_accumulate_2d_REAL64
+   end subroutine hist_buffer_accumulate_2d
 
    !#######################################################################
 
-   subroutine hist_buffer_norm_value_1dreal32(buffer, norm_val, logger)
-      use hist_msg_handler, only: hist_log_messages, hist_add_error
-      use hist_buffer,      only: hist_buffer_t
-
-      ! Dummy arguments
-      class(hist_buffer_t),    target,   intent(inout) :: buffer
-      real(REAL32),                      intent(inout) :: norm_val(:)
-      type(hist_log_messages), optional, intent(inout) :: logger
-      ! Local variables
-      class(hist_buff_1dreal32_t), pointer          :: buff32
-      class(hist_buff_1dreal64_t), pointer          :: buff64
-      real(REAL64),                     allocatable :: norm_val64(:)
-      character(len=:),                 allocatable :: buff_typestr
-      character(len=*), parameter :: subname = 'hist_buffer_norm_value_1dreal32'
-
-      select type(buffer)
-      class is (hist_buff_1dreal32_t)
-         buff32 => buffer
-         call buff32%norm_value(norm_val, logger=logger)
-      class is (hist_buff_1dreal64_t)
-         ! Truncate 64bit buffer into 32bit output
-         buff64 => buffer
-         allocate(norm_val64(size(norm_val, 1)))
-         call buff64%norm_value(norm_val64, logger=logger)
-         norm_val(:) = REAL(norm_val64(:), REAL32)
-      class default
-         buff_typestr = buffer%buffer_type()
-         call hist_add_error(subname, "unsupported buffer type, '",           &
-              errstr2=buff_typestr, errstr3="'", errors=logger)
-      end select
-
-   end subroutine hist_buffer_norm_value_1dreal32
-
-   !#######################################################################
-
-   subroutine hist_buffer_norm_value_1dreal64(buffer, norm_val, logger)
-      use hist_msg_handler, only: hist_log_messages, hist_add_error
-      use hist_buffer,      only: hist_buffer_t
+   subroutine hist_buffer_norm_value_1d(buffer, norm_val, logger)
+      use hist_buffer,      only: hist_buffer_t, hist_buff_1d_t
+      use hist_msg_handler, only: hist_log_messages
 
       ! Dummy arguments
       class(hist_buffer_t),    target,   intent(inout) :: buffer
       real(REAL64),                      intent(inout) :: norm_val(:)
       type(hist_log_messages), optional, intent(inout) :: logger
-      ! Local variables
-      type(hist_buff_1dreal32_t), pointer          :: buff32
-      type(hist_buff_1dreal64_t), pointer          :: buff64
-      real(REAL32),                    allocatable :: norm_val32(:)
-      character(len=:),                allocatable :: buff_typestr
-      character(len=*), parameter :: subname = 'hist_buffer_norm_value_1dreal64'
+      ! Local variable
+      class(hist_buff_1d_t) , pointer :: buff
 
-      select type(buffer)
-      class is (hist_buff_1dreal32_t)
-         ! Do we want to read out 32bit buffers into 64bit data?
-         buff32 => buffer
-         allocate(norm_val32(size(norm_val, 1)))
-         call buffer%norm_value(norm_val32, logger=logger)
-         norm_val(:) = REAL(norm_val32(:), REAL64)
-      class is (hist_buff_1dreal64_t)
-         buff64 => buffer
-         call buffer%norm_value(norm_val, logger=logger)
-      class default
-         buff_typestr = buffer%buffer_type()
-         call hist_add_error(subname, "unsupported buffer type, '",           &
-              errstr2=buff_typestr, errstr3="'", errors=logger)
+      select type (buffer)
+      class is (hist_buff_1d_t)
+         buff => buffer
+         call buff%norm_value(norm_val, logger=logger)
       end select
 
-   end subroutine hist_buffer_norm_value_1dreal64
+   end subroutine hist_buffer_norm_value_1d
 
    !#######################################################################
 
-   subroutine hist_buffer_norm_value_2dreal32(buffer, norm_val, logger)
-      use hist_msg_handler, only: hist_log_messages, hist_add_error
-      use hist_buffer,      only: hist_buffer_t
-
-      ! Dummy arguments
-      class(hist_buffer_t),    target,   intent(inout) :: buffer
-      real(REAL32),                      intent(inout) :: norm_val(:,:)
-      type(hist_log_messages), optional, intent(inout) :: logger
-      ! Local variables
-      class(hist_buff_2dreal32_t), pointer          :: buff32
-      class(hist_buff_2dreal64_t), pointer          :: buff64
-      real(REAL64),                     allocatable :: norm_val64(:,:)
-      character(len=:),                 allocatable :: buff_typestr
-      character(len=*), parameter :: subname = 'hist_buffer_norm_value_2dreal32'
-
-      select type(buffer)
-      class is (hist_buff_2dreal32_t)
-         buff32 => buffer
-         call buff32%norm_value(norm_val, logger=logger)
-      class is (hist_buff_2dreal64_t)
-         ! Truncate 64bit buffer into 32bit output
-         buff64 => buffer
-         allocate(norm_val64(size(norm_val, 1), size(norm_val, 2)))
-         call buff64%norm_value(norm_val64, logger=logger)
-         norm_val(:,:) = REAL(norm_val64(:,:), REAL32)
-      class default
-         buff_typestr = buffer%buffer_type()
-         call hist_add_error(subname, "unsupported buffer type, '",           &
-              errstr2=buff_typestr, errstr3="'", errors=logger)
-      end select
-
-   end subroutine hist_buffer_norm_value_2dreal32
-
-   !#######################################################################
-
-   subroutine hist_buffer_norm_value_2dreal64(buffer, norm_val, logger)
-      use hist_msg_handler, only: hist_log_messages, hist_add_error
-      use hist_buffer,      only: hist_buffer_t
+   subroutine hist_buffer_norm_value_2d(buffer, norm_val, logger)
+      use hist_buffer,      only: hist_buffer_t, hist_buff_2d_t
+      use hist_msg_handler, only: hist_log_messages
 
       ! Dummy arguments
       class(hist_buffer_t),    target,   intent(inout) :: buffer
       real(REAL64),                      intent(inout) :: norm_val(:,:)
       type(hist_log_messages), optional, intent(inout) :: logger
-      ! Local variables
-      type(hist_buff_2dreal32_t), pointer          :: buff32
-      type(hist_buff_2dreal64_t), pointer          :: buff64
-      real(REAL32),                    allocatable :: norm_val32(:,:)
-      character(len=:),                allocatable :: buff_typestr
-      character(len=*), parameter :: subname = 'hist_buffer_norm_value_1dreal64'
+      ! Local variable
+      class(hist_buff_2d_t), pointer :: buff
 
-      select type(buffer)
-      class is (hist_buff_2dreal32_t)
-         ! Do we want to read out 32bit buffers into 64bit data?
-         buff32 => buffer
-         allocate(norm_val32(size(norm_val, 1), size(norm_val, 2)))
-         call buffer%norm_value(norm_val32, logger=logger)
-         norm_val(:,:) = REAL(norm_val32(:,:), REAL64)
-      class is (hist_buff_2dreal64_t)
-         buff64 => buffer
-         call buffer%norm_value(norm_val, logger=logger)
-      class default
-         buff_typestr = buffer%buffer_type()
-         call hist_add_error(subname, "unsupported buffer type, '",           &
-              errstr2=buff_typestr, errstr3="'", errors=logger)
+      select type (buffer)
+      class is (hist_buff_2d_t)
+         buff => buffer
+         call buff%norm_value(norm_val, logger=logger)
       end select
 
-   end subroutine hist_buffer_norm_value_2dreal64
+   end subroutine hist_buffer_norm_value_2d
 
 end module hist_api

--- a/src/hist_api.F90
+++ b/src/hist_api.F90
@@ -1,7 +1,5 @@
 module hist_api
 
-   use ISO_FORTRAN_ENV, only: REAL64, INT32, INT64
-
    implicit none
    private
 
@@ -9,9 +7,7 @@ module hist_api
    public :: hist_new_field         ! Allocate a hist_field_info_t object
    public :: hist_new_buffer        ! Create a new field buffer
    public :: hist_field_accumulate  ! Accumulate a new field state in all buffs
-   public :: hist_field_norm_value  ! Grab the norm value from field buffer
-   public :: hist_buffer_accumulate ! Accumulate a new field state
-   public :: hist_buffer_norm_value ! Return current normalized field state
+   public :: hist_field_norm_value  ! Grab the normalized value from field buffer
 
    ! Interfaces for public interfaces
    interface hist_field_accumulate
@@ -24,16 +20,6 @@ module hist_api
       module procedure hist_field_norm_value_2d
    end interface hist_field_norm_value
 
-   interface hist_buffer_accumulate
-      module procedure hist_buffer_accumulate_1d
-      module procedure hist_buffer_accumulate_2d
-   end interface hist_buffer_accumulate
-
-   interface hist_buffer_norm_value
-      module procedure hist_buffer_norm_value_1d
-      module procedure hist_buffer_norm_value_2d
-   end interface hist_buffer_norm_value
-
 CONTAINS
 
    !#######################################################################
@@ -44,6 +30,7 @@ CONTAINS
         cell_methods, errors) result(new_field)
       use hist_msg_handler, only: hist_have_error, hist_log_messages, ERROR
       use hist_field,       only: hist_field_initialize, hist_field_info_t
+      use ISO_FORTRAN_ENV,  only: REAL64
 
       type(hist_field_info_t), pointer                 :: new_field
       character(len=*),                  intent(in)    :: diag_name_in
@@ -188,6 +175,11 @@ CONTAINS
               "Unknown accumulation operator type, '",                        &
               errstr2=trim(accum_type)//"'", errors=errors)
       end select
+      ! Only real values handled right now
+      if (trim(type_str) /= 'real') then
+         call hist_add_error(subname, 'buffer type ', errstr2=type_str,       &
+                 errstr3=' unsupported', errors=errors)
+      end if
       ! We now know what sort of buffer we need
       ! Based on rank
       select case (rank)
@@ -240,7 +232,8 @@ CONTAINS
       use hist_msg_handler, only: hist_log_messages, hist_have_error, ERROR
       use hist_msg_handler, only: hist_add_message, VERBOSE
       use hist_field,       only: hist_field_info_t
-      use hist_buffer,      only: hist_buffer_t
+      use hist_buffer,      only: hist_buff_1d_t, hist_buffer_t
+      use ISO_FORTRAN_ENV,  only: REAL64
 
       ! Dummy arguments
       class(hist_field_info_t), pointer,  intent(inout) :: field
@@ -250,6 +243,7 @@ CONTAINS
       type(hist_log_messages),  optional, intent(inout) :: logger
       ! Local variables
       class(hist_buffer_t), pointer     :: buff_ptr
+      class(hist_buff_1d_t), pointer    :: buff
       character(len=*), parameter :: subname = 'hist_field_accumulate_1d'
 
       if (associated(field)) then
@@ -257,21 +251,24 @@ CONTAINS
          do
             if (associated(buff_ptr) .and.                                    &
                  (.not. hist_have_error(errors=logger))) then
-               call hist_buffer_accumulate(buff_ptr, data, cols_or_block,     &
-                    field%flag_xyfill(), field%fill_value(), cole=cole,       &
-                    logger=logger)
-               if (hist_have_error(errors=logger)) then
-                  call  logger%add_stack_frame(ERROR, __FILE__, __LINE__ - 3, &
-                       subname=subname)
-                  exit
-               else
-                  call hist_add_message(subname, VERBOSE,                     &
-                       "Accumulated data for",                                &
-                       msgstr2=trim(field%diag_name())//", Buffer type, ",    &
-                       msgstr3=trim(buff_ptr%buffer_type()),                  &
-                       logger=logger)
-                  buff_ptr => buff_ptr%next
-               end if
+               select type(buff_ptr)
+               class is (hist_buff_1d_t)
+                  buff => buff_ptr
+                  call buff%accumulate(data, cols_or_block, field%flag_xyfill(), &
+                          field%fill_value(), cole, logger)
+                  if (hist_have_error(errors=logger)) then
+                     call  logger%add_stack_frame(ERROR, __FILE__, __LINE__ - 3, &
+                          subname=subname)
+                     exit
+                  else
+                     call hist_add_message(subname, VERBOSE,                     &
+                          "Accumulated data for",                                &
+                          msgstr2=trim(field%diag_name())//", Buffer type, ",    &
+                          msgstr3=trim(buff%buffer_type()),                  &
+                          logger=logger)
+                  end if
+               end select
+               buff_ptr => buff_ptr%next
             else
                exit
             end if
@@ -287,7 +284,8 @@ CONTAINS
       use hist_msg_handler, only: hist_log_messages, hist_have_error, ERROR
       use hist_msg_handler, only: hist_add_message, VERBOSE
       use hist_field,       only: hist_field_info_t
-      use hist_buffer,      only: hist_buffer_t
+      use hist_buffer,      only: hist_buff_2d_t, hist_buffer_t
+      use ISO_FORTRAN_ENV,  only: REAL64
 
       ! Dummy arguments
       class(hist_field_info_t), pointer,  intent(inout) :: field
@@ -297,6 +295,7 @@ CONTAINS
       type(hist_log_messages),  optional, intent(inout) :: logger
       ! Local variables
       class(hist_buffer_t), pointer     :: buff_ptr
+      class(hist_buff_2d_t), pointer    :: buff
       character(len=*),     parameter   :: subname = 'hist_field_accumulate_2d'
 
       if (associated(field)) then
@@ -304,21 +303,24 @@ CONTAINS
          do
             if (associated(buff_ptr) .and.                                    &
                  (.not. hist_have_error(errors=logger))) then
-               call hist_buffer_accumulate(buff_ptr, data, cols_or_block,     &
-                    field%flag_xyfill(), field%fill_value(), cole=cole,       &
-                    logger=logger)
-               if (hist_have_error(errors=logger)) then
-                  call  logger%add_stack_frame(ERROR, __FILE__, __LINE__ - 3, &
-                       subname=subname)
-                  exit
-               else
-                  call hist_add_message(subname, VERBOSE,                     &
-                       "Accumulated data for",                                &
-                       msgstr2=trim(field%diag_name())//", Buffer type, ",    &
-                       msgstr3=trim(buff_ptr%buffer_type()),                  &
-                       logger=logger)
-                  buff_ptr => buff_ptr%next
-               end if
+               select type (buff_ptr)
+               class is (hist_buff_2d_t)
+                  buff => buff_ptr
+                  call buff%accumulate(data, cols_or_block, field%flag_xyfill(), &
+                          field%fill_value(), cole, logger)
+                  if (hist_have_error(errors=logger)) then
+                     call  logger%add_stack_frame(ERROR, __FILE__, __LINE__ - 3, &
+                          subname=subname)
+                     exit
+                  else
+                     call hist_add_message(subname, VERBOSE,                     &
+                          "Accumulated data for",                                &
+                          msgstr2=trim(field%diag_name())//", Buffer type, ",    &
+                          msgstr3=trim(buff%buffer_type()),                  &
+                          logger=logger)
+                  end if
+               end select
+               buff_ptr => buff_ptr%next
             else
                exit
             end if
@@ -329,87 +331,41 @@ CONTAINS
 
    !#######################################################################
 
-   subroutine hist_buffer_accumulate_1d(buffer, field, cols_or_block,   &
-        flag_xyfill, fill_value, cole, logger)
-      use hist_buffer,      only: hist_buffer_t, hist_buff_1d_t
-      use hist_msg_handler, only: hist_log_messages
-
-      ! Dummy arguments
-      class(hist_buffer_t),    target,   intent(inout) :: buffer
-      real(REAL64),                      intent(in)    :: field(:)
-      integer,                           intent(in)    :: cols_or_block
-      logical,                           intent(in)    :: flag_xyfill
-      real(REAL64),                      intent(in)    :: fill_value
-      integer,                 optional, intent(in)    :: cole
-      type(hist_log_messages), optional, intent(inout) :: logger
-      ! Local variable
-      class(hist_buff_1d_t), pointer :: buff
-
-      select type (buffer)
-      class is (hist_buff_1d_t)
-         buff => buffer
-         call buff%accumulate(field, cols_or_block, flag_xyfill, fill_value, cole, logger)
-      end select
-
-   end subroutine hist_buffer_accumulate_1d
-
-   !#######################################################################
-
-   subroutine hist_buffer_accumulate_2d(buffer, field, cols_or_block,   &
-        flag_xyfill, fill_value, cole, logger)
-      use hist_buffer,      only: hist_buffer_t, hist_buff_2d_t
-      use hist_msg_handler, only: hist_log_messages
-
-      ! Dummy arguments
-      class(hist_buffer_t),    target,   intent(inout) :: buffer
-      real(REAL64),                      intent(in)    :: field(:,:)
-      integer,                           intent(in)    :: cols_or_block
-      logical,                           intent(in)    :: flag_xyfill
-      real(REAL64),                      intent(in)    :: fill_value
-      integer,                 optional, intent(in)    :: cole
-      type(hist_log_messages), optional, intent(inout) :: logger
-      ! Local variable
-      class(hist_buff_2d_t), pointer :: buff
-
-      select type (buffer)
-      class is (hist_buff_2d_t)
-         buff => buffer
-         call buff%accumulate(field, cols_or_block, flag_xyfill, fill_value, cole, logger)
-      end select
-
-   end subroutine hist_buffer_accumulate_2d
-
-   !#######################################################################
-
    subroutine hist_field_norm_value_1d(field, norm_val, logger)
-      use hist_buffer,      only: hist_buffer_t
+      use hist_buffer,      only: hist_buffer_t, hist_buff_1d_t
       use hist_msg_handler, only: hist_log_messages, hist_have_error, ERROR
       use hist_msg_handler, only: hist_add_message, VERBOSE
       use hist_field,       only: hist_field_info_t
+      use ISO_FORTRAN_ENV,  only: REAL64
 
       ! Dummy arguments
-      class(hist_field_info_t), intent(inout) :: field
+      class(hist_field_info_t),          intent(inout) :: field
       real(REAL64),                      intent(inout) :: norm_val(:)
       type(hist_log_messages), optional, intent(inout) :: logger
       ! Local variables
-      class(hist_buffer_t), pointer :: buff_ptr
-      character(len=*), parameter   :: subname = 'hist_field_norm_value_1d'
+      class(hist_buffer_t), pointer  :: buff_ptr
+      class(hist_buff_1d_t), pointer :: buff
+      character(len=*), parameter    :: subname = 'hist_field_norm_value_1d'
 
       buff_ptr => field%buffers
       if (associated(buff_ptr) .and.                                  &
          (.not. hist_have_error(errors=logger))) then
-         call hist_buffer_norm_value(buff_ptr, norm_val,              &
-            field%flag_xyfill(), field%fill_value(), logger=logger)
-         if (hist_have_error(errors=logger)) then
-            call logger%add_stack_frame(ERROR, __FILE__, __LINE__-3,  &
-               subname=subname)
-         else
-            call hist_add_message(subname, VERBOSE,                   &
-               "Accumulated data for",                                &
-               msgstr2=trim(field%diag_name())//", Buffer type, ",    &
-               msgstr3=trim(buff_ptr%buffer_type()),                  &
-               logger=logger)
-          end if
+         select type(buff_ptr)
+         class is (hist_buff_1d_t)
+            buff => buff_ptr
+            call buff%norm_value(norm_val, field%flag_xyfill(), &
+                    field%fill_value(), logger=logger)
+            if (hist_have_error(errors=logger)) then
+               call logger%add_stack_frame(ERROR, __FILE__, __LINE__-3,  &
+                  subname=subname)
+            else
+               call hist_add_message(subname, VERBOSE,                   &
+                  "Accumulated data for",                                &
+                  msgstr2=trim(field%diag_name())//", Buffer type, ",    &
+                  msgstr3=trim(buff%buffer_type()),                  &
+                  logger=logger)
+            end if
+         end select
       end if
 
    end subroutine hist_field_norm_value_1d
@@ -417,84 +373,42 @@ CONTAINS
    !#######################################################################
 
    subroutine hist_field_norm_value_2d(field, norm_val, logger)
-      use hist_buffer,      only: hist_buffer_t
+      use hist_buffer,      only: hist_buffer_t, hist_buff_2d_t
       use hist_msg_handler, only: hist_log_messages, hist_have_error, ERROR
       use hist_msg_handler, only: hist_add_message, VERBOSE
       use hist_field,       only: hist_field_info_t
+      use ISO_FORTRAN_ENV,  only: REAL64
 
       ! Dummy arguments
       class(hist_field_info_t),          intent(inout) :: field
       real(REAL64),                      intent(inout) :: norm_val(:,:)
       type(hist_log_messages), optional, intent(inout) :: logger
       ! Local variables
-      class(hist_buffer_t), pointer :: buff_ptr
-      character(len=*), parameter   :: subname = 'hist_field_norm_value_2d'
+      class(hist_buffer_t), pointer  :: buff_ptr
+      class(hist_buff_2d_t), pointer :: buff
+      character(len=*), parameter    :: subname = 'hist_field_norm_value_2d'
 
       buff_ptr => field%buffers
       if (associated(buff_ptr) .and.                                  &
          (.not. hist_have_error(errors=logger))) then
-         call hist_buffer_norm_value(buff_ptr, norm_val,              &
-            field%flag_xyfill(), field%fill_value(), logger=logger)
-         if (hist_have_error(errors=logger)) then
-            call logger%add_stack_frame(ERROR, __FILE__, __LINE__-3,  &
-               subname=subname)
-         else
-            call hist_add_message(subname, VERBOSE,                   &
-               "Accumulated data for",                                &
-               msgstr2=trim(field%diag_name())//", Buffer type, ",    &
-               msgstr3=trim(buff_ptr%buffer_type()),                  &
-               logger=logger)
-         end if
+         select type(buff_ptr)
+         class is (hist_buff_2d_t)
+            buff => buff_ptr
+            call buff%norm_value(norm_val, field%flag_xyfill(), &
+                    field%fill_value(), logger=logger)
+            if (hist_have_error(errors=logger)) then
+              call logger%add_stack_frame(ERROR, __FILE__, __LINE__-3,  &
+                 subname=subname)
+            else
+               call hist_add_message(subname, VERBOSE,                   &
+                  "Accumulated data for",                                &
+                  msgstr2=trim(field%diag_name())//", Buffer type, ",    &
+                  msgstr3=trim(buff_ptr%buffer_type()),                  &
+                  logger=logger)
+            end if
+         end select
       end if
 
    end subroutine hist_field_norm_value_2d
-
-   !#######################################################################
-
-   subroutine hist_buffer_norm_value_1d(buffer, norm_val, flag_xyfill, fill_value, &
-      logger)
-      use hist_buffer,      only: hist_buffer_t, hist_buff_1d_t
-      use hist_msg_handler, only: hist_log_messages
-
-      ! Dummy arguments
-      class(hist_buffer_t),    target,   intent(inout) :: buffer
-      real(REAL64),                      intent(inout) :: norm_val(:)
-      logical,                           intent(in)    :: flag_xyfill
-      real(REAL64),                      intent(in)    :: fill_value
-      type(hist_log_messages), optional, intent(inout) :: logger
-      ! Local variable
-      class(hist_buff_1d_t) , pointer :: buff
-
-      select type (buffer)
-      class is (hist_buff_1d_t)
-         buff => buffer
-         call buff%norm_value(norm_val, flag_xyfill, fill_value, logger=logger)
-      end select
-
-   end subroutine hist_buffer_norm_value_1d
-
-   !#######################################################################
-
-   subroutine hist_buffer_norm_value_2d(buffer, norm_val, flag_xyfill, fill_value, &
-      logger)
-      use hist_buffer,      only: hist_buffer_t, hist_buff_2d_t
-      use hist_msg_handler, only: hist_log_messages
-
-      ! Dummy arguments
-      class(hist_buffer_t),    target,   intent(inout) :: buffer
-      real(REAL64),                      intent(inout) :: norm_val(:,:)
-      logical,                           intent(in)    :: flag_xyfill
-      real(REAL64),                      intent(in)    :: fill_value
-      type(hist_log_messages), optional, intent(inout) :: logger
-      ! Local variable
-      class(hist_buff_2d_t), pointer :: buff
-
-      select type (buffer)
-      class is (hist_buff_2d_t)
-         buff => buffer
-         call buff%norm_value(norm_val, flag_xyfill, fill_value, logger=logger)
-      end select
-
-   end subroutine hist_buffer_norm_value_2d
 
 end module hist_api

--- a/src/hist_api.F90
+++ b/src/hist_api.F90
@@ -87,7 +87,7 @@ CONTAINS
 
    !#######################################################################
 
-   subroutine hist_new_buffer(field, buff_shape, buff_kind, horiz_axis_ind,   &
+   subroutine hist_new_buffer(field, buff_shape, horiz_axis_ind,   &
         accum_type, output_vol, errors, block_ind, block_sizes)
       use hist_msg_handler, only: hist_log_messages, hist_add_error
       use hist_msg_handler, only: hist_add_alloc_error, ERROR
@@ -100,7 +100,6 @@ CONTAINS
       ! Dummy arguments
       class(hist_field_info_t), pointer                 :: field
       integer,                            intent(in)    :: buff_shape(:)
-      integer,                            intent(in)    :: buff_kind
       integer,                            intent(in)    :: horiz_axis_ind
       character(len=*),                   intent(in)    :: accum_type
       integer,                            intent(in)    :: output_vol

--- a/src/hist_api.F90
+++ b/src/hist_api.F90
@@ -230,7 +230,7 @@ CONTAINS
    subroutine hist_field_accumulate_1d(field, data, cols_or_block,      &
         cole, logger)
       use hist_msg_handler, only: hist_log_messages, hist_have_error, ERROR
-      use hist_msg_handler, only: hist_add_message, VERBOSE
+      use hist_msg_handler, only: hist_add_message, VERBOSE, hist_add_error
       use hist_field,       only: hist_field_info_t
       use hist_buffer,      only: hist_buff_1d_t, hist_buffer_t
       use ISO_FORTRAN_ENV,  only: REAL64
@@ -267,6 +267,8 @@ CONTAINS
                           msgstr3=trim(buff%buffer_type()),                  &
                           logger=logger)
                   end if
+               class default
+                  call hist_add_error(subname, 'invalid buffer type', errors=errors)
                end select
                buff_ptr => buff_ptr%next
             else
@@ -282,7 +284,7 @@ CONTAINS
    subroutine hist_field_accumulate_2d(field, data, cols_or_block,      &
         cole, logger)
       use hist_msg_handler, only: hist_log_messages, hist_have_error, ERROR
-      use hist_msg_handler, only: hist_add_message, VERBOSE
+      use hist_msg_handler, only: hist_add_message, VERBOSE, hist_add_error
       use hist_field,       only: hist_field_info_t
       use hist_buffer,      only: hist_buff_2d_t, hist_buffer_t
       use ISO_FORTRAN_ENV,  only: REAL64
@@ -319,6 +321,8 @@ CONTAINS
                           msgstr3=trim(buff%buffer_type()),                  &
                           logger=logger)
                   end if
+               class default
+                  call hist_add_error(subname, 'invalid buffer type', errors=errors)
                end select
                buff_ptr => buff_ptr%next
             else
@@ -334,7 +338,7 @@ CONTAINS
    subroutine hist_field_norm_value_1d(field, norm_val, logger)
       use hist_buffer,      only: hist_buffer_t, hist_buff_1d_t
       use hist_msg_handler, only: hist_log_messages, hist_have_error, ERROR
-      use hist_msg_handler, only: hist_add_message, VERBOSE
+      use hist_msg_handler, only: hist_add_message, VERBOSE, hist_add_error
       use hist_field,       only: hist_field_info_t
       use ISO_FORTRAN_ENV,  only: REAL64
 
@@ -365,6 +369,8 @@ CONTAINS
                   msgstr3=trim(buff%buffer_type()),                  &
                   logger=logger)
             end if
+         class default
+            call hist_add_error(subname, 'invalid buffer type', errors=errors)
          end select
       end if
 
@@ -375,7 +381,7 @@ CONTAINS
    subroutine hist_field_norm_value_2d(field, norm_val, logger)
       use hist_buffer,      only: hist_buffer_t, hist_buff_2d_t
       use hist_msg_handler, only: hist_log_messages, hist_have_error, ERROR
-      use hist_msg_handler, only: hist_add_message, VERBOSE
+      use hist_msg_handler, only: hist_add_message, VERBOSE, hist_add_error
       use hist_field,       only: hist_field_info_t
       use ISO_FORTRAN_ENV,  only: REAL64
 
@@ -406,6 +412,8 @@ CONTAINS
                   msgstr3=trim(buff_ptr%buffer_type()),                  &
                   logger=logger)
             end if
+         class default
+            call hist_add_error(subname, 'invalid buffer type', errors=errors)
          end select
       end if
 

--- a/src/hist_api.F90
+++ b/src/hist_api.F90
@@ -268,7 +268,7 @@ CONTAINS
                           logger=logger)
                   end if
                class default
-                  call hist_add_error(subname, 'invalid buffer type', errors=errors)
+                  call hist_add_error(subname, 'invalid buffer type', errors=logger)
                end select
                buff_ptr => buff_ptr%next
             else
@@ -322,7 +322,7 @@ CONTAINS
                           logger=logger)
                   end if
                class default
-                  call hist_add_error(subname, 'invalid buffer type', errors=errors)
+                  call hist_add_error(subname, 'invalid buffer type', errors=logger)
                end select
                buff_ptr => buff_ptr%next
             else
@@ -370,7 +370,7 @@ CONTAINS
                   logger=logger)
             end if
          class default
-            call hist_add_error(subname, 'invalid buffer type', errors=errors)
+            call hist_add_error(subname, 'invalid buffer type', errors=logger)
          end select
       end if
 
@@ -413,7 +413,7 @@ CONTAINS
                   logger=logger)
             end if
          class default
-            call hist_add_error(subname, 'invalid buffer type', errors=errors)
+            call hist_add_error(subname, 'invalid buffer type', errors=logger)
          end select
       end if
 

--- a/src/hist_api.F90
+++ b/src/hist_api.F90
@@ -9,6 +9,7 @@ module hist_api
    public :: hist_new_field         ! Allocate a hist_field_info_t object
    public :: hist_new_buffer        ! Create a new field buffer
    public :: hist_field_accumulate  ! Accumulate a new field state in all buffs
+   public :: hist_field_norm_value  ! Grab the norm value from field buffer
    public :: hist_buffer_accumulate ! Accumulate a new field state
    public :: hist_buffer_norm_value ! Return current normalized field state
 
@@ -17,6 +18,11 @@ module hist_api
       module procedure hist_field_accumulate_1d
       module procedure hist_field_accumulate_2d
    end interface hist_field_accumulate
+
+   interface hist_field_norm_value
+      module procedure hist_field_norm_value_1d
+      module procedure hist_field_norm_value_2d
+   end interface hist_field_norm_value
 
    interface hist_buffer_accumulate
       module procedure hist_buffer_accumulate_1d
@@ -114,8 +120,6 @@ CONTAINS
       integer                              :: shape_idx
       integer,                 allocatable :: beg_dims(:), end_dims(:)
       integer,                 allocatable :: buffer_shape(:)
-      real(REAL64)                         :: fill_value
-      logical                              :: xyfill_flag
       character(len=8)                     :: kind_string
       character(len=3)                     :: accum_string
       character(len=16)                    :: bufftype_string
@@ -207,10 +211,8 @@ CONTAINS
          if (size(buffer_shape) > 1) then
             buffer_shape(2) = buff_shape(2)
          end if
-         fill_value = field%fill_value()
-         xyfill_flag = field%flag_xyfill()
          call buffer%initialize(field_base, output_vol, horiz_axis_ind,       &
-              accum_val, fill_value, buffer_shape, xyfill_flag, block_sizes, block_ind, &
+              accum_val, buffer_shape, block_sizes, block_ind, &
               logger=errors)
          ! Add this buffer to its field (field should be there if buffer is)
          if (associated(field%buffers)) then
@@ -256,7 +258,8 @@ CONTAINS
             if (associated(buff_ptr) .and.                                    &
                  (.not. hist_have_error(errors=logger))) then
                call hist_buffer_accumulate(buff_ptr, data, cols_or_block,     &
-                    cole=cole, logger=logger)
+                    field%flag_xyfill(), field%fill_value(), cole=cole,       &
+                    logger=logger)
                if (hist_have_error(errors=logger)) then
                   call  logger%add_stack_frame(ERROR, __FILE__, __LINE__ - 3, &
                        subname=subname)
@@ -302,7 +305,8 @@ CONTAINS
             if (associated(buff_ptr) .and.                                    &
                  (.not. hist_have_error(errors=logger))) then
                call hist_buffer_accumulate(buff_ptr, data, cols_or_block,     &
-                    cole=cole, logger=logger)
+                    field%flag_xyfill(), field%fill_value(), cole=cole,       &
+                    logger=logger)
                if (hist_have_error(errors=logger)) then
                   call  logger%add_stack_frame(ERROR, __FILE__, __LINE__ - 3, &
                        subname=subname)
@@ -326,7 +330,7 @@ CONTAINS
    !#######################################################################
 
    subroutine hist_buffer_accumulate_1d(buffer, field, cols_or_block,   &
-        cole, logger)
+        flag_xyfill, fill_value, cole, logger)
       use hist_buffer,      only: hist_buffer_t, hist_buff_1d_t
       use hist_msg_handler, only: hist_log_messages
 
@@ -334,6 +338,8 @@ CONTAINS
       class(hist_buffer_t),    target,   intent(inout) :: buffer
       real(REAL64),                      intent(in)    :: field(:)
       integer,                           intent(in)    :: cols_or_block
+      logical,                           intent(in)    :: flag_xyfill
+      real(REAL64),                      intent(in)    :: fill_value
       integer,                 optional, intent(in)    :: cole
       type(hist_log_messages), optional, intent(inout) :: logger
       ! Local variable
@@ -342,7 +348,7 @@ CONTAINS
       select type (buffer)
       class is (hist_buff_1d_t)
          buff => buffer
-         call buff%accumulate(field, cols_or_block, cole, logger)
+         call buff%accumulate(field, cols_or_block, flag_xyfill, fill_value, cole, logger)
       end select
 
    end subroutine hist_buffer_accumulate_1d
@@ -350,7 +356,7 @@ CONTAINS
    !#######################################################################
 
    subroutine hist_buffer_accumulate_2d(buffer, field, cols_or_block,   &
-        cole, logger)
+        flag_xyfill, fill_value, cole, logger)
       use hist_buffer,      only: hist_buffer_t, hist_buff_2d_t
       use hist_msg_handler, only: hist_log_messages
 
@@ -358,6 +364,8 @@ CONTAINS
       class(hist_buffer_t),    target,   intent(inout) :: buffer
       real(REAL64),                      intent(in)    :: field(:,:)
       integer,                           intent(in)    :: cols_or_block
+      logical,                           intent(in)    :: flag_xyfill
+      real(REAL64),                      intent(in)    :: fill_value
       integer,                 optional, intent(in)    :: cole
       type(hist_log_messages), optional, intent(inout) :: logger
       ! Local variable
@@ -366,20 +374,93 @@ CONTAINS
       select type (buffer)
       class is (hist_buff_2d_t)
          buff => buffer
-         call buff%accumulate(field, cols_or_block, cole, logger)
+         call buff%accumulate(field, cols_or_block, flag_xyfill, fill_value, cole, logger)
       end select
 
    end subroutine hist_buffer_accumulate_2d
 
    !#######################################################################
 
-   subroutine hist_buffer_norm_value_1d(buffer, norm_val, logger)
+   subroutine hist_field_norm_value_1d(field, norm_val, logger)
+      use hist_buffer,      only: hist_buffer_t
+      use hist_msg_handler, only: hist_log_messages, hist_have_error, ERROR
+      use hist_msg_handler, only: hist_add_message, VERBOSE
+      use hist_field,       only: hist_field_info_t
+
+      ! Dummy arguments
+      class(hist_field_info_t), intent(inout) :: field
+      real(REAL64),                      intent(inout) :: norm_val(:)
+      type(hist_log_messages), optional, intent(inout) :: logger
+      ! Local variables
+      class(hist_buffer_t), pointer :: buff_ptr
+      character(len=*), parameter   :: subname = 'hist_field_norm_value_1d'
+
+      buff_ptr => field%buffers
+      if (associated(buff_ptr) .and.                                  &
+         (.not. hist_have_error(errors=logger))) then
+         call hist_buffer_norm_value(buff_ptr, norm_val,              &
+            field%flag_xyfill(), field%fill_value(), logger=logger)
+         if (hist_have_error(errors=logger)) then
+            call logger%add_stack_frame(ERROR, __FILE__, __LINE__-3,  &
+               subname=subname)
+         else
+            call hist_add_message(subname, VERBOSE,                   &
+               "Accumulated data for",                                &
+               msgstr2=trim(field%diag_name())//", Buffer type, ",    &
+               msgstr3=trim(buff_ptr%buffer_type()),                  &
+               logger=logger)
+          end if
+      end if
+
+   end subroutine hist_field_norm_value_1d
+
+   !#######################################################################
+
+   subroutine hist_field_norm_value_2d(field, norm_val, logger)
+      use hist_buffer,      only: hist_buffer_t
+      use hist_msg_handler, only: hist_log_messages, hist_have_error, ERROR
+      use hist_msg_handler, only: hist_add_message, VERBOSE
+      use hist_field,       only: hist_field_info_t
+
+      ! Dummy arguments
+      class(hist_field_info_t),          intent(inout) :: field
+      real(REAL64),                      intent(inout) :: norm_val(:,:)
+      type(hist_log_messages), optional, intent(inout) :: logger
+      ! Local variables
+      class(hist_buffer_t), pointer :: buff_ptr
+      character(len=*), parameter   :: subname = 'hist_field_norm_value_2d'
+
+      buff_ptr => field%buffers
+      if (associated(buff_ptr) .and.                                  &
+         (.not. hist_have_error(errors=logger))) then
+         call hist_buffer_norm_value(buff_ptr, norm_val,              &
+            field%flag_xyfill(), field%fill_value(), logger=logger)
+         if (hist_have_error(errors=logger)) then
+            call logger%add_stack_frame(ERROR, __FILE__, __LINE__-3,  &
+               subname=subname)
+         else
+            call hist_add_message(subname, VERBOSE,                   &
+               "Accumulated data for",                                &
+               msgstr2=trim(field%diag_name())//", Buffer type, ",    &
+               msgstr3=trim(buff_ptr%buffer_type()),                  &
+               logger=logger)
+         end if
+      end if
+
+   end subroutine hist_field_norm_value_2d
+
+   !#######################################################################
+
+   subroutine hist_buffer_norm_value_1d(buffer, norm_val, flag_xyfill, fill_value, &
+      logger)
       use hist_buffer,      only: hist_buffer_t, hist_buff_1d_t
       use hist_msg_handler, only: hist_log_messages
 
       ! Dummy arguments
       class(hist_buffer_t),    target,   intent(inout) :: buffer
       real(REAL64),                      intent(inout) :: norm_val(:)
+      logical,                           intent(in)    :: flag_xyfill
+      real(REAL64),                      intent(in)    :: fill_value
       type(hist_log_messages), optional, intent(inout) :: logger
       ! Local variable
       class(hist_buff_1d_t) , pointer :: buff
@@ -387,20 +468,23 @@ CONTAINS
       select type (buffer)
       class is (hist_buff_1d_t)
          buff => buffer
-         call buff%norm_value(norm_val, logger=logger)
+         call buff%norm_value(norm_val, flag_xyfill, fill_value, logger=logger)
       end select
 
    end subroutine hist_buffer_norm_value_1d
 
    !#######################################################################
 
-   subroutine hist_buffer_norm_value_2d(buffer, norm_val, logger)
+   subroutine hist_buffer_norm_value_2d(buffer, norm_val, flag_xyfill, fill_value, &
+      logger)
       use hist_buffer,      only: hist_buffer_t, hist_buff_2d_t
       use hist_msg_handler, only: hist_log_messages
 
       ! Dummy arguments
       class(hist_buffer_t),    target,   intent(inout) :: buffer
       real(REAL64),                      intent(inout) :: norm_val(:,:)
+      logical,                           intent(in)    :: flag_xyfill
+      real(REAL64),                      intent(in)    :: fill_value
       type(hist_log_messages), optional, intent(inout) :: logger
       ! Local variable
       class(hist_buff_2d_t), pointer :: buff
@@ -408,7 +492,7 @@ CONTAINS
       select type (buffer)
       class is (hist_buff_2d_t)
          buff => buffer
-         call buff%norm_value(norm_val, logger=logger)
+         call buff%norm_value(norm_val, flag_xyfill, fill_value, logger=logger)
       end select
 
    end subroutine hist_buffer_norm_value_2d

--- a/src/hist_api.F90
+++ b/src/hist_api.F90
@@ -43,8 +43,8 @@ CONTAINS
    !#######################################################################
 
    function hist_new_field(diag_name_in, std_name_in, long_name_in, units_in, &
-        type_in, decomp_in, dimensions, acc_flag, num_levels, field_shape, sampling_seq,  &
-        flag_xyfill, mixing_ratio, dim_bounds, mdim_sizes, beg_dims, end_dims,  &
+        type_in, decomp_in, dimensions, acc_flag, num_levels, field_shape, fill_value, &
+        sampling_seq, flag_xyfill, mixing_ratio, dim_bounds, mdim_sizes, beg_dims, end_dims,  &
         cell_methods, errors) result(new_field)
       use hist_msg_handler, only: hist_have_error, hist_log_messages, ERROR
       use hist_field,       only: hist_field_initialize, hist_field_info_t
@@ -60,6 +60,7 @@ CONTAINS
       character(len=*),                  intent(in)    :: acc_flag
       integer,                           intent(in)    :: field_shape(:)
       integer,                           intent(in)    :: num_levels
+      real(kind=REAL64),                 intent(in)    :: fill_value
       character(len=*),        optional, intent(in)    :: sampling_seq
       logical,                 optional, intent(in)    :: flag_xyfill
       character(len=*),        optional, intent(in)    :: mixing_ratio
@@ -84,8 +85,9 @@ CONTAINS
          call hist_field_initialize(new_field, diag_name_in, std_name_in,     &
               long_name_in, units_in, type_in, decomp_in, dimensions, acc_flag,  &
               num_levels, field_shape, sampling_seq=sampling_seq, flag_xyfill=flag_xyfill,   &
-              mixing_ratio=mixing_ratio, dim_bounds=dim_bounds, mdim_sizes=mdim_sizes, &
-              beg_dims=beg_dims, end_dims=end_dims, cell_methods=cell_methods, errmsg=errmsg)
+              fill_value=fill_value, mixing_ratio=mixing_ratio, dim_bounds=dim_bounds, &
+              mdim_sizes=mdim_sizes, beg_dims=beg_dims, end_dims=end_dims, &
+              cell_methods=cell_methods, errmsg=errmsg)
          if (hist_have_error(errors=errors)) then
             call errors%add_stack_frame(ERROR, __FILE__, __LINE__ - 3,        &
                  subname=subname)
@@ -123,6 +125,8 @@ CONTAINS
       integer                              :: shape_idx
       integer,                 allocatable :: beg_dims(:), end_dims(:)
       integer,                 allocatable :: buffer_shape(:)
+      real(REAL64)                         :: fill_value
+      logical                              :: xyfill_flag
       character(len=8)                     :: kind_string
       character(len=3)                     :: accum_string
       character(len=16)                    :: bufftype_string
@@ -252,8 +256,11 @@ CONTAINS
          if (size(buffer_shape) > 1) then
             buffer_shape(2) = buff_shape(2)
          end if
+         fill_value = field%fill_value()
+         xyfill_flag = field%flag_xyfill()
          call buffer%initialize(field_base, output_vol, horiz_axis_ind,       &
-              accum_val, buffer_shape, block_sizes, block_ind, logger=errors)
+              accum_val, fill_value, buffer_shape, xyfill_flag, block_sizes, block_ind, &
+              logger=errors)
          ! Add this buffer to its field (field should be there if buffer is)
          if (associated(field%buffers)) then
             buff_ptr => field%buffers
@@ -601,15 +608,13 @@ CONTAINS
 
    !#######################################################################
 
-   subroutine hist_buffer_norm_value_1dreal32(buffer, norm_val, default_val,  &
-        logger)
+   subroutine hist_buffer_norm_value_1dreal32(buffer, norm_val, logger)
       use hist_msg_handler, only: hist_log_messages, hist_add_error
       use hist_buffer,      only: hist_buffer_t
 
       ! Dummy arguments
       class(hist_buffer_t),    target,   intent(inout) :: buffer
       real(REAL32),                      intent(inout) :: norm_val(:)
-      real(REAL32),            optional, intent(in)    :: default_val
       type(hist_log_messages), optional, intent(inout) :: logger
       ! Local variables
       class(hist_buff_1dreal32_t), pointer          :: buff32
@@ -621,18 +626,12 @@ CONTAINS
       select type(buffer)
       class is (hist_buff_1dreal32_t)
          buff32 => buffer
-         call buff32%norm_value(norm_val, default_val=default_val,            &
-              logger=logger)
+         call buff32%norm_value(norm_val, logger=logger)
       class is (hist_buff_1dreal64_t)
          ! Truncate 64bit buffer into 32bit output
          buff64 => buffer
          allocate(norm_val64(size(norm_val, 1)))
-         if (present(default_val)) then
-            call buff64%norm_value(norm_val64,                                &
-                 default_val=REAL(default_val, REAL64), logger=logger)
-         else
-            call buff64%norm_value(norm_val64, logger=logger)
-         end if
+         call buff64%norm_value(norm_val64, logger=logger)
          norm_val(:) = REAL(norm_val64(:), REAL32)
       class default
          buff_typestr = buffer%buffer_type()
@@ -644,15 +643,13 @@ CONTAINS
 
    !#######################################################################
 
-   subroutine hist_buffer_norm_value_1dreal64(buffer, norm_val, default_val,  &
-      logger)
+   subroutine hist_buffer_norm_value_1dreal64(buffer, norm_val, logger)
       use hist_msg_handler, only: hist_log_messages, hist_add_error
       use hist_buffer,      only: hist_buffer_t
 
       ! Dummy arguments
       class(hist_buffer_t),    target,   intent(inout) :: buffer
       real(REAL64),                      intent(inout) :: norm_val(:)
-      real(REAL64),            optional, intent(in)    :: default_val
       type(hist_log_messages), optional, intent(inout) :: logger
       ! Local variables
       type(hist_buff_1dreal32_t), pointer          :: buff32
@@ -666,17 +663,11 @@ CONTAINS
          ! Do we want to read out 32bit buffers into 64bit data?
          buff32 => buffer
          allocate(norm_val32(size(norm_val, 1)))
-         if (present(default_val)) then
-            call buffer%norm_value(norm_val32,                                &
-                 default_val=REAL(default_val, REAL32), logger=logger)
-         else
-            call buffer%norm_value(norm_val32, logger=logger)
-         end if
+         call buffer%norm_value(norm_val32, logger=logger)
          norm_val(:) = REAL(norm_val32(:), REAL64)
       class is (hist_buff_1dreal64_t)
          buff64 => buffer
-         call buffer%norm_value(norm_val, default_val=default_val,            &
-              logger=logger)
+         call buffer%norm_value(norm_val, logger=logger)
       class default
          buff_typestr = buffer%buffer_type()
          call hist_add_error(subname, "unsupported buffer type, '",           &
@@ -687,15 +678,13 @@ CONTAINS
 
    !#######################################################################
 
-   subroutine hist_buffer_norm_value_2dreal32(buffer, norm_val, default_val,  &
-        logger)
+   subroutine hist_buffer_norm_value_2dreal32(buffer, norm_val, logger)
       use hist_msg_handler, only: hist_log_messages, hist_add_error
       use hist_buffer,      only: hist_buffer_t
 
       ! Dummy arguments
       class(hist_buffer_t),    target,   intent(inout) :: buffer
       real(REAL32),                      intent(inout) :: norm_val(:,:)
-      real(REAL32),            optional, intent(in)    :: default_val
       type(hist_log_messages), optional, intent(inout) :: logger
       ! Local variables
       class(hist_buff_2dreal32_t), pointer          :: buff32
@@ -707,18 +696,12 @@ CONTAINS
       select type(buffer)
       class is (hist_buff_2dreal32_t)
          buff32 => buffer
-         call buff32%norm_value(norm_val, default_val=default_val,            &
-              logger=logger)
+         call buff32%norm_value(norm_val, logger=logger)
       class is (hist_buff_2dreal64_t)
          ! Truncate 64bit buffer into 32bit output
          buff64 => buffer
          allocate(norm_val64(size(norm_val, 1), size(norm_val, 2)))
-         if (present(default_val)) then
-            call buff64%norm_value(norm_val64,                                &
-                 default_val=REAL(default_val, REAL64), logger=logger)
-         else
-            call buff64%norm_value(norm_val64, logger=logger)
-         end if
+         call buff64%norm_value(norm_val64, logger=logger)
          norm_val(:,:) = REAL(norm_val64(:,:), REAL32)
       class default
          buff_typestr = buffer%buffer_type()
@@ -730,15 +713,13 @@ CONTAINS
 
    !#######################################################################
 
-   subroutine hist_buffer_norm_value_2dreal64(buffer, norm_val, default_val,  &
-      logger)
+   subroutine hist_buffer_norm_value_2dreal64(buffer, norm_val, logger)
       use hist_msg_handler, only: hist_log_messages, hist_add_error
       use hist_buffer,      only: hist_buffer_t
 
       ! Dummy arguments
       class(hist_buffer_t),    target,   intent(inout) :: buffer
       real(REAL64),                      intent(inout) :: norm_val(:,:)
-      real(REAL64),            optional, intent(in)    :: default_val
       type(hist_log_messages), optional, intent(inout) :: logger
       ! Local variables
       type(hist_buff_2dreal32_t), pointer          :: buff32
@@ -752,17 +733,11 @@ CONTAINS
          ! Do we want to read out 32bit buffers into 64bit data?
          buff32 => buffer
          allocate(norm_val32(size(norm_val, 1), size(norm_val, 2)))
-         if (present(default_val)) then
-            call buffer%norm_value(norm_val32,                                &
-                 default_val=REAL(default_val, REAL32), logger=logger)
-         else
-            call buffer%norm_value(norm_val32, logger=logger)
-         end if
+         call buffer%norm_value(norm_val32, logger=logger)
          norm_val(:,:) = REAL(norm_val32(:,:), REAL64)
       class is (hist_buff_2dreal64_t)
          buff64 => buffer
-         call buffer%norm_value(norm_val, default_val=default_val,            &
-              logger=logger)
+         call buffer%norm_value(norm_val, logger=logger)
       class default
          buff_typestr = buffer%buffer_type()
          call hist_add_error(subname, "unsupported buffer type, '",           &

--- a/src/hist_buffer.F90
+++ b/src/hist_buffer.F90
@@ -7,7 +7,7 @@ module hist_buffer
 
    ! Public interfaces
    public :: buffer_factory
-
+   
    ! Accumulation types -- the integers and array positions below must match
    integer, parameter, public :: hist_accum_lst = 1 ! last sample
    integer, parameter, public :: hist_accum_min = 2 ! minimum sample
@@ -33,6 +33,8 @@ module hist_buffer
       integer,                             private :: horiz_axis_ind = 0
       integer,                             private :: rank = 0
       integer,                             private :: accum_type = 0
+      logical,                             private :: flag_xyfill = .false.
+      real(REAL64),                        private :: fill_value
       integer,                allocatable, private :: field_shape(:)
       integer,                allocatable, private :: block_begs(:)
       integer,                allocatable, private :: block_ends(:)
@@ -70,6 +72,7 @@ module hist_buffer
       procedure :: accumulate => buff_2dreal32_accum
       procedure :: norm_value => buff_2dreal32_value
       procedure :: initialize => init_buff_2dreal32
+      procedure :: check_fill_value => buff_2dreal32_check_fill
    end type hist_buff_2dreal32_t
 
    type, public, extends(hist_buffer_t) :: hist_buff_1dreal64_t
@@ -90,6 +93,7 @@ module hist_buffer
       procedure :: accumulate => buff_2dreal64_accum
       procedure :: norm_value => buff_2dreal64_value
       procedure :: initialize => init_buff_2dreal64
+      procedure :: check_fill_value => buff_2dreal64_check_fill
    end type hist_buff_2dreal64_t
 
    ! Abstract interfaces for hist_buffer_t class
@@ -104,8 +108,10 @@ module hist_buffer
 
    abstract interface
       subroutine hist_buff_init(this, field_in, volume_in, horiz_axis_in,     &
-           accum_type_in, shape_in, block_sizes_in, block_ind_in, logger)
+           accum_type_in, fill_val_in, shape_in, flag_xyfill_in, block_sizes_in, &
+           block_ind_in, logger)
          use hist_msg_handler, only: hist_log_messages
+         use ISO_FORTRAN_ENV, only: REAL64
          import                   :: hist_buffer_t
          import                   :: hist_hashable_t
          class(hist_buffer_t),              intent(inout) :: this
@@ -113,7 +119,9 @@ module hist_buffer
          integer,                           intent(in)    :: volume_in
          integer,                           intent(in)    :: horiz_axis_in
          integer,                           intent(in)    :: accum_type_in
+         real(REAL64),                      intent(in)    :: fill_val_in
          integer,                           intent(in)    :: shape_in(:)
+         logical,                           intent(in)    :: flag_xyfill_in
          integer,                 optional, intent(in)    :: block_sizes_in(:)
          integer,                 optional, intent(in)    :: block_ind_in
          type(hist_log_messages), optional, intent(inout) :: logger
@@ -206,7 +214,8 @@ CONTAINS
    !#######################################################################
 
    subroutine init_buffer(this, field_in, volume_in, horiz_axis_in,           &
-        accum_type_in, shape_in, block_sizes_in, block_ind_in, logger)
+        accum_type_in, fill_val_in, shape_in, flag_xyfill_in, block_sizes_in, &
+        block_ind_in, logger)
       use hist_msg_handler, only: hist_log_messages, hist_add_alloc_error
       use hist_msg_handler, only: hist_add_error
 
@@ -216,7 +225,9 @@ CONTAINS
       integer,                           intent(in)    :: volume_in
       integer,                           intent(in)    :: horiz_axis_in
       integer,                           intent(in)    :: accum_type_in
+      real(REAL64),                      intent(in)    :: fill_val_in
       integer,                           intent(in)    :: shape_in(:)
+      logical,                           intent(in)    :: flag_xyfill_in
       integer,                 optional, intent(in)    :: block_sizes_in(:)
       integer,                 optional, intent(in)    :: block_ind_in
       type(hist_log_messages), optional, intent(inout) :: logger
@@ -236,6 +247,8 @@ CONTAINS
          this%vol = volume_in
          this%horiz_axis_ind = horiz_axis_in
          this%accum_type = accum_type_in
+         this%fill_value = fill_val_in
+         this%flag_xyfill = flag_xyfill_in
          allocate(this%field_shape(size(shape_in, 1)), stat=astat)
          if (astat == 0) then
             this%field_shape(:) = shape_in(:)
@@ -303,9 +316,9 @@ CONTAINS
 
    !#######################################################################
 
-   subroutine init_buff_1dreal32(this, field_in, volume_in,              &
-        horiz_axis_in, accum_type_in, shape_in, block_sizes_in, block_ind_in, &
-        logger)
+   subroutine init_buff_1dreal32(this, field_in, volume_in, horiz_axis_in, &
+        accum_type_in, fill_val_in, shape_in, flag_xyfill_in, block_sizes_in, &
+        block_ind_in, logger)
       use hist_msg_handler, only: hist_log_messages, hist_add_alloc_error
 
       ! Dummy arguments
@@ -314,12 +327,15 @@ CONTAINS
       integer,                           intent(in)    :: volume_in
       integer,                           intent(in)    :: horiz_axis_in
       integer,                           intent(in)    :: accum_type_in
+      real(REAL64),                      intent(in)    :: fill_val_in
       integer,                           intent(in)    :: shape_in(:)
+      logical,                           intent(in)    :: flag_xyfill_in
       integer,                 optional, intent(in)    :: block_sizes_in(:)
       integer,                 optional, intent(in)    :: block_ind_in
       type(hist_log_messages), optional, intent(inout) :: logger
-      call init_buffer(this, field_in, volume_in, horiz_axis_in,              &
-           accum_type_in, shape_in, block_sizes_in, block_ind_in, logger=logger)
+      call init_buffer(this, field_in, volume_in, horiz_axis_in, accum_type_in, &
+              fill_val_in, shape_in, flag_xyfill_in, block_sizes_in, &
+              block_ind_in, logger=logger)
       call this%clear(logger=logger)
       this%buff_type = 'buff_1dreal32'
 
@@ -358,13 +374,12 @@ CONTAINS
 
    !#######################################################################
 
-   subroutine buff_2dreal32_value(this, norm_val, default_val, logger)
+   subroutine buff_2dreal32_value(this, norm_val, logger)
       use hist_msg_handler, only: hist_log_messages
 
       ! Dummy arguments
       class(hist_buff_2dreal32_t),       intent(inout) :: this
       real(REAL32),                      intent(inout) :: norm_val(:,:)
-      real(REAL32),            optional, intent(in)    :: default_val
       type(hist_log_messages), optional, intent(inout) :: logger
       ! Local variable
       integer :: ind1, ind2
@@ -375,8 +390,8 @@ CONTAINS
             nacc = this%num_samples(ind1, ind2)
             if (nacc > 0) then
                norm_val(ind1, ind2) = this%data(ind1, ind2) / nacc
-            else if (present(default_val)) then
-               norm_val(ind1, ind2) = default_val
+            else if (this%flag_xyfill) then
+               norm_val(ind1, ind2) = this%fill_value
             end if
          end do
       end do
@@ -414,47 +429,136 @@ CONTAINS
          end if
       end if
 
-
       select case (this%accum_type)
       case (hist_accum_lst)
-         this%data(:,:) = field(:,:)
-         this%num_samples(:,:) = 1
+         do ind1 = col_beg_use, col_end_use
+            do ind2 = 1, size(field,2)
+               fld_val = field(ind1 - col_beg_use + 1, ind2)
+               if (this%flag_xyfill .and. fld_val == this%fill_value) then
+                  ! Set num samples to 0 if this is a fill value
+                  ! This will trigger logic in _value routine
+                  this%data(ind1, ind2) = this%fill_value
+                  this%num_samples(ind1, ind2) = 0
+               else
+                  this%data(ind1, ind2) = fld_val
+                  this%num_samples(ind1, ind2) = 1
+               end if
+            end do
+         end do
       case (hist_accum_min)
          do ind1 = col_beg_use, col_end_use
             do ind2 = 1, size(field, 2)
                fld_val = field(ind1 - col_beg_use + 1, ind2)
-               if (this%num_samples(ind1, ind2) == 0) then
-                  this%data(ind1, ind2) = fld_val
-               else if (fld_val < this%data(ind1, ind2)) then
-                  this%data(ind1, ind2) = fld_val
-               end if ! No else, we already have the minimum value for this col
-               this%num_samples(ind1, ind2) = 1
+               if (this%flag_xyfill) then
+                  ! If the buffer (possibly) contains fill values,
+                  ! only check for minimum if not a fill value
+                  if (this%num_samples(ind1, ind2) == 0) then
+                     if (fld_val /= this%fill_value) then
+                        this%data(ind1, ind2) = fld_val
+                        this%num_samples(ind1, ind2) = 1
+                     else
+                        ! Set to large positive number if this is a fill value
+                        ! Also do not change num_samples - if num_samples
+                        ! is zero at the end of the accumulation period,
+                        ! the value will be overwritten to fill_value
+                        this%data(ind1, ind2) = HUGE(REAL32)
+                     end if
+                  else if (fld_val < this%data(ind1, ind2) .and. fld_val /= this%fill_value) then
+                     this%data(ind1, ind2) = fld_val
+                     this%num_samples(ind1, ind2) = 1
+                  end if ! No else, we already have the minimum value for this col
+               else
+                  if (this%num_samples(ind1, ind2) == 0 .or. fld_val < this%data(ind1, ind2)) then
+                     this%data(ind1, ind2) = fld_val
+                     this%num_samples(ind1, ind2) = 1
+                  end if ! No else, we already have the minimum value for this col
+               end if
             end do
          end do
+         if (this%flag_xyfill) then
+            call this%check_fill_value(field(col_beg_use:col_end_use, :), logger)
+         end if
       case (hist_accum_max)
          do ind1 = col_beg_use, col_end_use
             do ind2 = 1, size(field, 2)
                fld_val = field(ind1 - col_beg_use + 1, ind2)
-               if (this%num_samples(ind1, ind2) == 0) then
-                  this%data(ind1, ind2) = fld_val
-               else if (fld_val > this%data(ind1, ind2)) then
-                  this%data(ind1, ind2) = fld_val
-               end if ! No else, we already have the maximum value for this col
-               this%num_samples(ind1, ind2) = 1
+               if (this%flag_xyfill) then
+                  ! If the buffer (possibly) contains fill values,
+                  ! only check for maximum if not a fill value
+                  if (this%num_samples(ind1, ind2) == 0) then
+                     if (fld_val /= this%fill_value) then
+                        this%data(ind1, ind2) = fld_val
+                        this%num_samples(ind1, ind2) = 1
+                     else
+                        ! Set to large negative number if this is a fill value
+                        ! Also do not change num_samples - if num_samples
+                        ! is zero at the end of the accumulation period,
+                        ! the value will be overwritten to fill_value
+                        this%data(ind1, ind2) = -HUGE(REAL32)
+                     end if
+                  else if (fld_val > this%data(ind1, ind2) .and. fld_val /= this%fill_value) then
+                     this%data(ind1, ind2) = fld_val
+                     this%num_samples(ind1, ind2) = 1
+                  end if ! No else, we already have the maximum value for this col
+               else
+                  if (this%num_samples(ind1, ind2) == 0 .or. fld_val > this%data(ind1, ind2)) then
+                     this%data(ind1, ind2) = fld_val
+                     this%num_samples(ind1, ind2) = 1
+                  end if ! No else, we already have the maximum value for this col
+               end if
             end do
          end do
+         if (this%flag_xyfill) then
+            call this%check_fill_value(field(col_beg_use:col_end_use, :), logger)
+         end if
       case (hist_accum_avg)
          do ind1 = col_beg_use, col_end_use
             do ind2 = 1, size(field, 2)
                fld_val = field(ind1 - col_beg_use + 1, ind2)
                ! Compute running sum
-               this%data(ind1, ind2) = this%data(ind1, ind2) + fld_val
-               this%num_samples(ind1, ind2) = this%num_samples(ind1, ind2) + 1
+               if (this%flag_xyfill) then
+                  ! Only include sample if it's not a fill value
+                  if (fld_val /= real(this%fill_value, REAL32)) then
+                     this%data(ind1, ind2) = this%data(ind1, ind2) + fld_val
+                     this%num_samples(ind1, ind2) = this%num_samples(ind1, ind2) + 1
+                  end if
+               else
+                  this%data(ind1, ind2) = this%data(ind1, ind2) + fld_val
+                  this%num_samples(ind1, ind2) = this%num_samples(ind1, ind2) + 1
+               end if
             end do
          end do
+         if (this%flag_xyfill) then
+            call this%check_fill_value(field(col_beg_use:col_end_use, :), logger)
+         end if
       end select
 
    end subroutine buff_2dreal32_accum
+
+   !#######################################################################
+
+   subroutine buff_2dreal32_check_fill(this, field, logger)
+      use hist_msg_handler, only: hist_log_messages, hist_add_error, ERROR
+      ! Ensure that columns have fillvalue applied consistently across levels
+      class(hist_buff_2dreal32_t),       intent(inout) :: this
+      real(REAL32),                      intent(in)    :: field(:,:)
+      type(hist_log_messages), optional, intent(inout) :: logger
+      ! Local variables
+      character(len=512) :: errstr
+      integer :: idx, jdx
+
+      do jdx = 2, size(field, 2)
+         do idx = 1, size(field, 1)
+            if (field(idx,1) == real(this%fill_value, REAL32) .and. &
+                 field(idx,jdx) /= real(this%fill_value, REAL32) .or. &
+                 field(idx,1) /= real(this%fill_value, REAL32) .and. &
+                 field(idx,jdx) == real(this%fill_value, REAL32)) then
+               write(errstr, '(a,i0)') 'ERROR: fill value applied inconsistently for column ', idx
+               call hist_add_error('buff_2dreal32_check_fill', errstr, errors=logger)
+            end if
+         end do
+      end do
+   end subroutine buff_2dreal32_check_fill
 
    !#######################################################################
 
@@ -489,33 +593,87 @@ CONTAINS
 
       select case (this%accum_type)
       case (hist_accum_lst)
-         this%data(col_beg_use:col_end_use) = field(:)
-         this%num_samples(col_beg_use:col_end_use) = 1
+         do ind1 = col_beg_use, col_end_use
+            fld_val = field(ind1 - col_beg_use + 1)
+            if (this%flag_xyfill .and. fld_val == real(this%fill_value, REAL32)) then
+               ! Set num samples to 0 if this is a fill value
+               ! This will trigger logic in _value routine
+               this%data(ind1) = real(this%fill_value, REAL32)
+               this%num_samples = 0
+            else
+               this%data(ind1) = fld_val
+               this%num_samples(ind1) = 1
+            end if
+         end do
       case (hist_accum_min)
          do ind1 = col_beg_use, col_end_use
             fld_val = field(ind1 - col_beg_use + 1)
-            if (this%num_samples(ind1) == 0) then
-               this%data(ind1) = fld_val
-            else if (fld_val < this%data(ind1)) then
-               this%data(ind1) = fld_val
-            end if ! No else, we already have the minimum value for this col
-            this%num_samples(ind1) = 1
+            if (this%flag_xyfill) then
+               ! If the buffer (possibly) contains fill values,
+               ! only check for minimum if not a fill value
+               if (this%num_samples(ind1) == 0) then
+                  if (fld_val /= real(this%fill_value, REAL32)) then
+                     this%data(ind1) = fld_val
+                     this%num_samples(ind1) = 1
+                  else
+                     ! Set to large positive number if this is a fill value
+                     ! Also do not change num_samples - if num_samples
+                     ! is zero at the end of the accumulation period,
+                     ! the value will be overwritten to fill_value
+                     this%data(ind1) = HUGE(REAL32)
+                  end if
+               else if (fld_val < this%data(ind1) .and. fld_val /= real(this%fill_value, REAL32)) then
+                  this%data(ind1) = fld_val
+                  this%num_samples(ind1) = 1
+               end if ! No else, we already have the minimum value for this col
+            else
+               if (this%num_samples(ind1) == 0 .or. fld_val < this%data(ind1)) then
+                  this%data(ind1) = fld_val
+                  this%num_samples(ind1) = 1
+               end if ! No else, we already have the minimum value for this col
+            end if
          end do
       case (hist_accum_max)
          do ind1 = col_beg_use, col_end_use
             fld_val = field(ind1 - col_beg_use + 1)
-            if (this%num_samples(ind1) == 0) then
-               this%data(ind1) = fld_val
-            else if (fld_val > this%data(ind1)) then
-               this%data(ind1) = fld_val
-            end if ! No else, we already have the maximum value for this col
-            this%num_samples(ind1) = 1
+            if (this%flag_xyfill) then
+               ! If the buffer (possibly) contains fill values,
+               ! only check for maximum if not a fill value
+               if (this%num_samples(ind1) == 0) then
+                  if (fld_val /= real(this%fill_value, REAL32)) then
+                     this%data(ind1) = fld_val
+                     this%num_samples(ind1) = 1
+                  else
+                     ! Set to large negative number if this is a fill value
+                     ! Also do not change num_samples - if num_samples
+                     ! is zero at the end of the accumulation period,
+                     ! the value will be overwritten to fill_value
+                     this%data(ind1) = -HUGE(REAL32)
+                  end if
+               else if (fld_val > this%data(ind1) .and. fld_val /= real(this%fill_value, REAL32)) then
+                  this%data(ind1) = fld_val
+                  this%num_samples(ind1) = 1
+               end if ! No else, we already have the maximum value for this col
+            else
+               if (this%num_samples(ind1) == 0 .or. fld_val > this%data(ind1)) then
+                  this%data(ind1) = fld_val
+                  this%num_samples(ind1) = 1
+               end if ! No else, we already have the maximum value for this col
+            end if
          end do
       case (hist_accum_avg)
          do ind1 = col_beg_use, col_end_use
             fld_val = field(ind1 - col_beg_use + 1)
-            this%data(ind1) = this%data(ind1) + fld_val
-            this%num_samples(ind1) = this%num_samples(ind1) + 1
+            if (this%flag_xyfill) then
+               ! Only include samples that aren't fill values
+               if (this%data(ind1) /= real(this%fill_value, REAL32)) then
+                  this%data(ind1) = this%data(ind1) + fld_val
+                  this%num_samples(ind1) = this%num_samples(ind1) + 1
+               end if
+            else
+               this%data(ind1) = this%data(ind1) + fld_val
+               this%num_samples(ind1) = this%num_samples(ind1) + 1
+            end if
          end do
       end select
 
@@ -523,13 +681,12 @@ CONTAINS
 
    !#######################################################################
 
-   subroutine buff_1dreal32_value(this, norm_val, default_val, logger)
+   subroutine buff_1dreal32_value(this, norm_val, logger)
       use hist_msg_handler, only: hist_log_messages
 
       ! Dummy arguments
       class(hist_buff_1dreal32_t),       intent(inout) :: this
       real(REAL32),                      intent(inout) :: norm_val(:)
-      real(REAL32),            optional, intent(in)    :: default_val
       type(hist_log_messages), optional, intent(inout) :: logger
       ! Local variable
       integer :: ind1
@@ -539,8 +696,8 @@ CONTAINS
          nacc = this%num_samples(ind1)
          if (nacc > 0) then
             norm_val(ind1) = this%data(ind1) / nacc
-         else if (present(default_val)) then
-            norm_val(ind1) = default_val
+         else if (this%flag_xyfill) then
+            norm_val(ind1) = this%fill_value
          end if
       end do
 
@@ -579,9 +736,9 @@ CONTAINS
 
    !#######################################################################
 
-   subroutine init_buff_1dreal64(this, field_in, volume_in,              &
-        horiz_axis_in, accum_type_in, shape_in, block_sizes_in, block_ind_in, &
-        logger)
+   subroutine init_buff_1dreal64(this, field_in, volume_in, horiz_axis_in, &
+        accum_type_in, fill_val_in, shape_in, flag_xyfill_in, block_sizes_in, &
+        block_ind_in, logger)
       use hist_msg_handler, only: hist_log_messages
 
       class(hist_buff_1dreal64_t),       intent(inout) :: this
@@ -589,13 +746,16 @@ CONTAINS
       integer,                           intent(in)    :: volume_in
       integer,                           intent(in)    :: horiz_axis_in
       integer,                           intent(in)    :: accum_type_in
+      real(REAL64),                      intent(in)    :: fill_val_in
       integer,                           intent(in)    :: shape_in(:)
+      logical,                           intent(in)    :: flag_xyfill_in
       integer,                 optional, intent(in)    :: block_sizes_in(:)
       integer,                 optional, intent(in)    :: block_ind_in
       type(hist_log_messages), optional, intent(inout) :: logger
 
-      call init_buffer(this, field_in, volume_in, horiz_axis_in,              &
-           accum_type_in, shape_in, block_sizes_in, block_ind_in, logger=logger)
+      call init_buffer(this, field_in, volume_in, horiz_axis_in, accum_type_in, &
+              fill_val_in, shape_in, flag_xyfill_in, block_sizes_in,&
+              block_ind_in, logger=logger)
       call this%clear(logger=logger)
       this%buff_type = 'buff_1dreal64'
 
@@ -633,33 +793,92 @@ CONTAINS
 
       select case (this%accum_type)
       case (hist_accum_lst)
-         this%data(col_beg_use:col_end_use) = field(:)
-         this%num_samples(col_beg_use:col_end_use) = 1
+         do ind1 = col_beg_use, col_end_use
+            fld_val = field(ind1 - col_beg_use + 1)
+            if (this%flag_xyfill) then
+               if (fld_val == this%fill_value) then
+                  ! Set num samples to 0 if this is a fill value
+                  ! This will trigger logic in _value routine
+                  this%data(ind1) = this%fill_value
+                  this%num_samples(ind1) = 0
+               else
+                  this%data(ind1) = fld_val
+                  this%num_samples(ind1) = 1
+               end if
+            else
+               this%data(ind1) = fld_val
+               this%num_samples(ind1) = 1
+            end if
+         end do
       case (hist_accum_min)
          do ind1 = col_beg_use, col_end_use
             fld_val = field(ind1 - col_beg_use + 1)
-            if (this%num_samples(ind1) == 0) then
-               this%data(ind1) = fld_val
-            else if (fld_val < this%data(ind1)) then
-               this%data(ind1) = fld_val
-            end if ! No else, we already have the minimum value for this col
-            this%num_samples(ind1) = 1
+            if (this%flag_xyfill) then
+               ! If the buffer (possibly) contains fill values,
+               ! only check for minimum if not a fill value
+               if (this%num_samples(ind1) == 0) then
+                  if (fld_val /= this%fill_value) then
+                     this%data(ind1) = fld_val
+                     this%num_samples(ind1) = 1
+                  else
+                     ! Set to large positive number if this is a fill value
+                     ! Also do not change num_samples - if num_samples
+                     ! is zero at the end of the accumulation period,
+                     ! the value will be overwritten to fill_value
+                     this%data(ind1) = HUGE(REAL64)
+                  end if
+               else if (fld_val < this%data(ind1) .and. fld_val /= this%fill_value) then
+                  this%data(ind1) = fld_val
+                  this%data(ind1) = 1
+               end if ! No else, we already have the minimum value for this col
+            else
+               if (this%num_samples(ind1) == 0 .or. fld_val < this%data(ind1)) then
+                  this%data(ind1) = fld_val
+                  this%num_samples(ind1) = 1
+               end if ! No else, we already have the minimum value for this col
+            end if
          end do
       case (hist_accum_max)
          do ind1 = col_beg_use, col_end_use
             fld_val = field(ind1 - col_beg_use + 1)
-            if (this%num_samples(ind1) == 0) then
-               this%data(ind1) = fld_val
-            else if (fld_val > this%data(ind1)) then
-               this%data(ind1) = fld_val
-            end if ! No else, we already have the maximum value for this col
-            this%num_samples(ind1) = 1
+            if (this%flag_xyfill) then
+               ! If the buffer (possibly) contains fill values,
+               ! only check for maximum if not a fill value
+               if (this%num_samples(ind1) == 0) then
+                  if (fld_val /= this%fill_value) then
+                     this%data(ind1) = fld_val
+                     this%num_samples(ind1) = 1
+                  else
+                     ! Set to large negative number if this is a fill value
+                     ! Also do not change num_samples - if num_samples
+                     ! is zero at the end of the accumulation period,
+                     ! the value will be overwritten to fill_value
+                     this%data(ind1) = -HUGE(REAL64)
+                  end if
+               else if (fld_val > this%data(ind1) .and. fld_val /= this%fill_value) then
+                  this%data(ind1) = fld_val
+                  this%num_samples(ind1) = 1
+               end if ! No else, we already have the maximum value for this col
+            else
+               if (this%num_samples(ind1) == 0 .or. fld_val > this%data(ind1)) then
+                  this%data(ind1) = fld_val
+                  this%num_samples(ind1) = 1
+               end if ! No else, we already have the maximum value for this col
+            end if
          end do
       case (hist_accum_avg)
          do ind1 = col_beg_use, col_end_use
             fld_val = field(ind1 - col_beg_use + 1)
-            this%data(ind1) = this%data(ind1) + fld_val
-            this%num_samples(ind1) = this%num_samples(ind1) + 1
+            if (this%flag_xyfill) then
+               ! Only include sample if not the fill value
+               if (fld_val /= this%fill_value) then
+                  this%data(ind1) = this%data(ind1) + fld_val
+                  this%num_samples(ind1) = this%num_samples(ind1) + 1
+               end if
+            else
+               this%data(ind1) = this%data(ind1) + fld_val
+               this%num_samples(ind1) = this%num_samples(ind1) + 1
+            end if
          end do
       end select
 
@@ -667,12 +886,11 @@ CONTAINS
 
    !#######################################################################
 
-   subroutine buff_1dreal64_value(this, norm_val, default_val, logger)
+   subroutine buff_1dreal64_value(this, norm_val, logger)
       use hist_msg_handler, only: hist_log_messages, ERROR, VERBOSE
       ! Dummy arguments
       class(hist_buff_1dreal64_t),       intent(inout) :: this
       real(REAL64),                      intent(inout) :: norm_val(:)
-      real(REAL64),            optional, intent(in)    :: default_val
       type(hist_log_messages), optional, intent(inout) :: logger
       ! Local variable
       integer :: ind1
@@ -682,8 +900,8 @@ CONTAINS
          nacc = this%num_samples(ind1)
          if (nacc > 0) then
             norm_val(ind1) = this%data(ind1) / nacc
-         else if (present(default_val)) then
-            norm_val(ind1) = default_val
+         else if (this%flag_xyfill) then
+            norm_val(ind1) = this%fill_value
          end if
       end do
 
@@ -722,9 +940,9 @@ CONTAINS
 
    !#######################################################################
 
-   subroutine init_buff_2dreal64(this, field_in, volume_in,              &
-        horiz_axis_in, accum_type_in, shape_in, block_sizes_in, block_ind_in, &
-        logger)
+   subroutine init_buff_2dreal64(this, field_in, volume_in, horiz_axis_in, &
+        accum_type_in, fill_val_in, shape_in, flag_xyfill_in, block_sizes_in, &
+        block_ind_in, logger)
       use hist_msg_handler, only: hist_log_messages
 
       class(hist_buff_2dreal64_t),       intent(inout) :: this
@@ -732,13 +950,16 @@ CONTAINS
       integer,                           intent(in)    :: volume_in
       integer,                           intent(in)    :: horiz_axis_in
       integer,                           intent(in)    :: accum_type_in
+      real(REAL64),                      intent(in)    :: fill_val_in
       integer,                           intent(in)    :: shape_in(:)
+      logical,                           intent(in)    :: flag_xyfill_in
       integer,                 optional, intent(in)    :: block_sizes_in(:)
       integer,                 optional, intent(in)    :: block_ind_in
       type(hist_log_messages), optional, intent(inout) :: logger
 
-      call init_buffer(this, field_in, volume_in, horiz_axis_in,              &
-           accum_type_in, shape_in, block_sizes_in, block_ind_in, logger=logger)
+      call init_buffer(this, field_in, volume_in, horiz_axis_in, accum_type_in, &
+              fill_val_in, shape_in, flag_xyfill_in, block_sizes_in, &
+              block_ind_in, logger=logger)
       call this%clear(logger=logger)
       this%buff_type = 'buff_2dreal64'
 
@@ -775,56 +996,142 @@ CONTAINS
          end if
       end if
 
-
       select case (this%accum_type)
       case (hist_accum_lst)
-         this%data = field
-         this%num_samples = 1
+         do ind1 = col_beg_use, col_end_use
+            do ind2 = 1, size(field,2)
+               fld_val = field(ind1 - col_beg_use + 1, ind2)
+               if (this%flag_xyfill .and. fld_val == this%fill_value) then
+                  ! Set num samples to 0 if this is a fill value
+                  ! This will trigger logic in _value routine
+                  this%data(ind1, ind2) = this%fill_value
+                  this%num_samples = 0
+               else
+                  this%data(ind1, ind2) = fld_val
+                  this%num_samples = 1
+               end if
+            end do
+         end do
       case (hist_accum_min)
          do ind1 = col_beg_use, col_end_use
             do ind2 = 1, size(field, 2)
                fld_val = field(ind1 - col_beg_use + 1, ind2)
-               if (this%num_samples(ind1, ind2) == 0) then
-                  this%data(ind1, ind2) = fld_val
-               else if (fld_val < this%data(ind1, ind2)) then
-                  this%data(ind1, ind2) = fld_val
-               end if ! No else, we already have the minimum value for this col
-               this%num_samples(ind1, ind2) = 1
+               if (this%flag_xyfill) then
+                  ! If the buffer (possibly) contains fill values,
+                  ! only check for minimum if not a fill value
+                  if (this%num_samples(ind1, ind2) == 0) then
+                     if (fld_val /= this%fill_value) then
+                        this%data(ind1, ind2) = fld_val
+                        this%num_samples(ind1, ind2) = 1
+                     else
+                        ! Set to large positive number if this is a fill value
+                        ! Also do not change num_samples - if num_samples
+                        ! is zero at the end of the accumulation period,
+                        ! the value will be overwritten to fill_value
+                        this%data(ind1, ind2) = HUGE(REAL64)
+                     end if
+                  else if (fld_val < this%data(ind1, ind2) .and. fld_val /= this%fill_value) then
+                     this%data(ind1, ind2) = fld_val
+                     this%num_samples(ind1, ind2) = 1
+                  end if ! No else, we already have the minimum value for this col
+               else
+                  if (this%num_samples(ind1, ind2) == 0 .or. fld_val < this%data(ind1, ind2)) then
+                     this%data(ind1, ind2) = fld_val
+                     this%num_samples(ind1, ind2) = 1
+                  end if ! No else, we already have the minimum value for this col
+               end if
             end do
          end do
+         if (this%flag_xyfill) then
+            call this%check_fill_value(field(col_beg_use:col_end_use, :), logger)
+         end if
       case (hist_accum_max)
          do ind1 = col_beg_use, col_end_use
             do ind2 = 1, size(field, 2)
                fld_val = field(ind1 - col_beg_use + 1, ind2)
-               if (this%num_samples(ind1, ind2) == 0) then
-                  this%data(ind1, ind2) = fld_val
-               else if (fld_val > this%data(ind1, ind2)) then
-                  this%data(ind1, ind2) = fld_val
-               end if ! No else, we already have the maximum value for this col
-               this%num_samples(ind1, ind2) = 1
+               if (this%flag_xyfill) then
+                  ! If the buffer (possibly) contains fill values,
+                  ! only check for maximum if not a fill value
+                  if (this%num_samples(ind1, ind2) == 0) then
+                     if (fld_val /= this%fill_value) then
+                        this%data(ind1, ind2) = fld_val
+                        this%num_samples(ind1, ind2) = 1
+                     else
+                        ! Set to large negative number if this is a fill value
+                        ! Also do not change num_samples - if num_samples
+                        ! is zero at the end of the accumulation period,
+                        ! the value will be overwritten to fill_value
+                        this%data(ind1, ind2) = -HUGE(REAL64)
+                     end if
+                  else if (fld_val > this%data(ind1, ind2) .and. fld_val /= this%fill_value) then
+                     this%data(ind1, ind2) = fld_val
+                     this%num_samples(ind1, ind2) = 1
+                  end if ! No else, we already have the maximum value for this col
+               else
+                  if (this%num_samples(ind1, ind2) == 0 .or. fld_val > this%data(ind1, ind2)) then
+                     this%data(ind1, ind2) = fld_val
+                     this%num_samples(ind1, ind2) = 1
+                  end if
+               end if
             end do
          end do
+         if (this%flag_xyfill) then
+            call this%check_fill_value(field(col_beg_use:col_end_use, :), logger)
+         end if
       case (hist_accum_avg)
          do ind1 = col_beg_use, col_end_use
             do ind2 = 1, size(field, 2)
                fld_val = field(ind1 - col_beg_use + 1, ind2)
                ! Compute running sum
-               this%data(ind1, ind2) = this%data(ind1, ind2) + fld_val
-               this%num_samples(ind1, ind2) = this%num_samples(ind1, ind2) + 1
+               if (this%flag_xyfill) then
+                  ! Only include sample if it is not the fill value
+                  if (fld_val /= this%fill_value) then
+                     this%data(ind1, ind2) = this%data(ind1, ind2) + fld_val
+                     this%num_samples(ind1, ind2) = this%num_samples(ind1, ind2) + 1
+                  end if
+               else
+                  this%data(ind1, ind2) = this%data(ind1, ind2) + fld_val
+                  this%num_samples(ind1, ind2) = this%num_samples(ind1, ind2) + 1
+               end if
             end do
          end do
+         if (this%flag_xyfill) then
+            call this%check_fill_value(field(col_beg_use:col_end_use, :), logger)
+         end if
       end select
 
    end subroutine buff_2dreal64_accum
 
    !#######################################################################
 
-   subroutine buff_2dreal64_value(this, norm_val, default_val, logger)
+   subroutine buff_2dreal64_check_fill(this, field, logger)
+      use hist_msg_handler, only: hist_log_messages, hist_add_error, ERROR
+      ! Ensure that columns have fill value applied consistently across levels
+      class(hist_buff_2dreal64_t),       intent(inout) :: this
+      real(REAL64),                      intent(in)    :: field(:,:)
+      type(hist_log_messages), optional, intent(inout) :: logger
+      ! Local variables
+      character(len=512) :: errstr
+      integer :: idx, jdx
+
+      do jdx = 2, size(field, 2)
+         do idx = 1, size(field, 1)
+            if (field(idx,1) == this%fill_value .and. field(idx,jdx) /= this%fill_value .or. &
+                 field(idx,1) /= this%fill_value .and. field(idx,jdx) == this%fill_value) then
+               write(errstr, '(a,i0)') 'ERROR: fill value applied inconsistently for column ', idx
+               call hist_add_error('buff_2dreal64_check_fill', errstr, errors=logger)
+            end if
+         end do
+      end do
+   end subroutine buff_2dreal64_check_fill
+
+   !#######################################################################
+
+   subroutine buff_2dreal64_value(this, norm_val, logger)
       use hist_msg_handler, only: hist_log_messages, ERROR, VERBOSE
       ! Dummy arguments
       class(hist_buff_2dreal64_t),       intent(inout) :: this
       real(REAL64),                      intent(inout) :: norm_val(:,:)
-      real(REAL64),            optional, intent(in)    :: default_val
       type(hist_log_messages), optional, intent(inout) :: logger
       ! Local variable
       integer :: ind1, ind2
@@ -835,8 +1142,8 @@ CONTAINS
             nacc = this%num_samples(ind1,ind2)
             if (nacc > 0) then
                norm_val(ind1, ind2) = this%data(ind1, ind2) / nacc
-            else if (present(default_val)) then
-               norm_val(ind1, ind2) = default_val
+            else if (this%flag_xyfill) then
+               norm_val(ind1, ind2) = this%fill_value
             end if
          end do
       end do
@@ -845,9 +1152,9 @@ CONTAINS
 
    !#######################################################################
 
-   subroutine init_buff_2dreal32(this, field_in, volume_in,              &
-        horiz_axis_in, accum_type_in, shape_in, block_sizes_in, block_ind_in, &
-        logger)
+   subroutine init_buff_2dreal32(this, field_in, volume_in, horiz_axis_in, &
+        accum_type_in, fill_val_in, shape_in, flag_xyfill_in, block_sizes_in, &
+        block_ind_in, logger)
       use hist_msg_handler, only: hist_log_messages
 
       class(hist_buff_2dreal32_t),       intent(inout) :: this
@@ -855,13 +1162,16 @@ CONTAINS
       integer,                           intent(in)    :: volume_in
       integer,                           intent(in)    :: horiz_axis_in
       integer,                           intent(in)    :: accum_type_in
+      real(REAL64),                      intent(in)    :: fill_val_in
       integer,                           intent(in)    :: shape_in(:)
+      logical,                           intent(in)    :: flag_xyfill_in
       integer,                 optional, intent(in)    :: block_sizes_in(:)
       integer,                 optional, intent(in)    :: block_ind_in
       type(hist_log_messages), optional, intent(inout) :: logger
 
-      call init_buffer(this, field_in, volume_in, horiz_axis_in,              &
-           accum_type_in, shape_in, block_sizes_in, block_ind_in, logger=logger)
+      call init_buffer(this, field_in, volume_in, horiz_axis_in, accum_type_in, &
+              fill_val_in, shape_in, flag_xyfill_in, block_sizes_in, &
+              block_ind_in, logger=logger)
       call this%clear(logger=logger)
       this%buff_type = 'buff_2dreal32'
 
@@ -929,5 +1239,7 @@ CONTAINS
               errstr2=trim(buffer_type), errstr3="'", errors=logger)
       end select
    end function buffer_factory
+
+   !#######################################################################
 
 end module hist_buffer

--- a/src/hist_buffer.F90
+++ b/src/hist_buffer.F90
@@ -33,8 +33,6 @@ module hist_buffer
       integer,                             private :: horiz_axis_ind = 0
       integer,                             private :: rank = 0
       integer,                             private :: accum_type = 0
-      logical,                             private :: flag_xyfill = .false.
-      real(REAL64),                        private :: fill_value
       integer,                allocatable, private :: field_shape(:)
       integer,                allocatable, private :: block_begs(:)
       integer,                allocatable, private :: block_ends(:)
@@ -89,8 +87,7 @@ module hist_buffer
 
    abstract interface
       subroutine hist_buff_init(this, field_in, volume_in, horiz_axis_in,     &
-           accum_type_in, fill_val_in, shape_in, flag_xyfill_in, block_sizes_in, &
-           block_ind_in, logger)
+           accum_type_in, shape_in, block_sizes_in, block_ind_in, logger)
          use hist_msg_handler, only: hist_log_messages
          use ISO_FORTRAN_ENV, only: REAL64
          import                   :: hist_buffer_t
@@ -100,9 +97,7 @@ module hist_buffer
          integer,                           intent(in)    :: volume_in
          integer,                           intent(in)    :: horiz_axis_in
          integer,                           intent(in)    :: accum_type_in
-         real(REAL64),                      intent(in)    :: fill_val_in
          integer,                           intent(in)    :: shape_in(:)
-         logical,                           intent(in)    :: flag_xyfill_in
          integer,                 optional, intent(in)    :: block_sizes_in(:)
          integer,                 optional, intent(in)    :: block_ind_in
          type(hist_log_messages), optional, intent(inout) :: logger
@@ -195,8 +190,7 @@ CONTAINS
    !#######################################################################
 
    subroutine init_buffer(this, field_in, volume_in, horiz_axis_in,           &
-        accum_type_in, fill_val_in, shape_in, flag_xyfill_in, block_sizes_in, &
-        block_ind_in, logger)
+        accum_type_in, shape_in, block_sizes_in, block_ind_in, logger)
       use hist_msg_handler, only: hist_log_messages, hist_add_alloc_error
       use hist_msg_handler, only: hist_add_error
 
@@ -206,9 +200,7 @@ CONTAINS
       integer,                           intent(in)    :: volume_in
       integer,                           intent(in)    :: horiz_axis_in
       integer,                           intent(in)    :: accum_type_in
-      real(REAL64),                      intent(in)    :: fill_val_in
       integer,                           intent(in)    :: shape_in(:)
-      logical,                           intent(in)    :: flag_xyfill_in
       integer,                 optional, intent(in)    :: block_sizes_in(:)
       integer,                 optional, intent(in)    :: block_ind_in
       type(hist_log_messages), optional, intent(inout) :: logger
@@ -228,8 +220,6 @@ CONTAINS
          this%vol = volume_in
          this%horiz_axis_ind = horiz_axis_in
          this%accum_type = accum_type_in
-         this%fill_value = fill_val_in
-         this%flag_xyfill = flag_xyfill_in
          allocate(this%field_shape(size(shape_in, 1)), stat=astat)
          if (astat == 0) then
             this%field_shape(:) = shape_in(:)
@@ -308,8 +298,7 @@ CONTAINS
    !#######################################################################
 
    subroutine init_buff_1d(this, field_in, volume_in, horiz_axis_in, &
-        accum_type_in, fill_val_in, shape_in, flag_xyfill_in, block_sizes_in, &
-        block_ind_in, logger)
+        accum_type_in, shape_in, block_sizes_in, block_ind_in, logger)
       use hist_msg_handler, only: hist_log_messages
 
       class(hist_buff_1d_t),       intent(inout) :: this
@@ -317,16 +306,13 @@ CONTAINS
       integer,                           intent(in)    :: volume_in
       integer,                           intent(in)    :: horiz_axis_in
       integer,                           intent(in)    :: accum_type_in
-      real(REAL64),                      intent(in)    :: fill_val_in
       integer,                           intent(in)    :: shape_in(:)
-      logical,                           intent(in)    :: flag_xyfill_in
       integer,                 optional, intent(in)    :: block_sizes_in(:)
       integer,                 optional, intent(in)    :: block_ind_in
       type(hist_log_messages), optional, intent(inout) :: logger
 
       call init_buffer(this, field_in, volume_in, horiz_axis_in, accum_type_in, &
-              fill_val_in, shape_in, flag_xyfill_in, block_sizes_in,&
-              block_ind_in, logger=logger)
+              shape_in, block_sizes_in, block_ind_in, logger=logger)
       call this%clear(logger=logger)
       this%buff_type = 'buff_1d'
 
@@ -334,12 +320,15 @@ CONTAINS
 
    !#######################################################################
 
-   subroutine buff_1d_accum(this, field, cols_or_block, cole, logger)
+   subroutine buff_1d_accum(this, field, cols_or_block, flag_xyfill, &
+         fill_value, cole, logger)
       use hist_msg_handler, only: hist_log_messages
       ! Dummy arguments
       class(hist_buff_1d_t),       intent(inout) :: this
       real(REAL64),                      intent(in)    :: field(:)
       integer,                           intent(in)    :: cols_or_block
+      logical,                           intent(in)    :: flag_xyfill
+      real(REAL64),                      intent(in)    :: fill_value
       integer,                 optional, intent(in)    :: cole
       type(hist_log_messages), optional, intent(inout) :: logger
       ! Local variables
@@ -366,11 +355,11 @@ CONTAINS
       case (hist_accum_lst)
          do ind1 = col_beg_use, col_end_use
             fld_val = field(ind1 - col_beg_use + 1)
-            if (this%flag_xyfill) then
-               if (fld_val == this%fill_value) then
+            if (flag_xyfill) then
+               if (fld_val == fill_value) then
                   ! Set num samples to 0 if this is a fill value
                   ! This will trigger logic in _value routine
-                  this%data(ind1) = this%fill_value
+                  this%data(ind1) = fill_value
                   this%num_samples(ind1) = 0
                else
                   this%data(ind1) = fld_val
@@ -384,11 +373,11 @@ CONTAINS
       case (hist_accum_min)
          do ind1 = col_beg_use, col_end_use
             fld_val = field(ind1 - col_beg_use + 1)
-            if (this%flag_xyfill) then
+            if (flag_xyfill) then
                ! If the buffer (possibly) contains fill values,
                ! only check for minimum if not a fill value
                if (this%num_samples(ind1) == 0) then
-                  if (fld_val /= this%fill_value) then
+                  if (fld_val /= fill_value) then
                      this%data(ind1) = fld_val
                      this%num_samples(ind1) = 1
                   else
@@ -398,7 +387,7 @@ CONTAINS
                      ! the value will be overwritten to fill_value
                      this%data(ind1) = HUGE(REAL64)
                   end if
-               else if (fld_val < this%data(ind1) .and. fld_val /= this%fill_value) then
+               else if (fld_val < this%data(ind1) .and. fld_val /= fill_value) then
                   this%data(ind1) = fld_val
                   this%data(ind1) = 1
                end if ! No else, we already have the minimum value for this col
@@ -412,11 +401,11 @@ CONTAINS
       case (hist_accum_max)
          do ind1 = col_beg_use, col_end_use
             fld_val = field(ind1 - col_beg_use + 1)
-            if (this%flag_xyfill) then
+            if (flag_xyfill) then
                ! If the buffer (possibly) contains fill values,
                ! only check for maximum if not a fill value
                if (this%num_samples(ind1) == 0) then
-                  if (fld_val /= this%fill_value) then
+                  if (fld_val /= fill_value) then
                      this%data(ind1) = fld_val
                      this%num_samples(ind1) = 1
                   else
@@ -426,7 +415,7 @@ CONTAINS
                      ! the value will be overwritten to fill_value
                      this%data(ind1) = -HUGE(REAL64)
                   end if
-               else if (fld_val > this%data(ind1) .and. fld_val /= this%fill_value) then
+               else if (fld_val > this%data(ind1) .and. fld_val /= fill_value) then
                   this%data(ind1) = fld_val
                   this%num_samples(ind1) = 1
                end if ! No else, we already have the maximum value for this col
@@ -440,9 +429,9 @@ CONTAINS
       case (hist_accum_avg)
          do ind1 = col_beg_use, col_end_use
             fld_val = field(ind1 - col_beg_use + 1)
-            if (this%flag_xyfill) then
+            if (flag_xyfill) then
                ! Only include sample if not the fill value
-               if (fld_val /= this%fill_value) then
+               if (fld_val /= fill_value) then
                   this%data(ind1) = this%data(ind1) + fld_val
                   this%num_samples(ind1) = this%num_samples(ind1) + 1
                end if
@@ -454,8 +443,8 @@ CONTAINS
       case (hist_accum_var)
          do ind1 = col_beg_use, col_end_use
             fld_val = field(ind1 - col_beg_use + 1)
-            if (this%flag_xyfill) then
-               if (fld_val /= real(this%fill_value, REAL64)) then
+            if (flag_xyfill) then
+               if (fld_val /= fill_value) then
                   ! Only include the sample if it's not a fill value
                   if (this%num_samples(ind1) == 0) then
                      this%data(ind1) = fld_val
@@ -495,11 +484,13 @@ CONTAINS
 
    !#######################################################################
 
-   subroutine buff_1d_value(this, norm_val, logger)
+   subroutine buff_1d_value(this, norm_val, flag_xyfill, fill_value, logger)
       use hist_msg_handler, only: hist_log_messages, ERROR, VERBOSE
       ! Dummy arguments
-      class(hist_buff_1d_t),       intent(inout) :: this
+      class(hist_buff_1d_t),             intent(inout) :: this
       real(REAL64),                      intent(inout) :: norm_val(:)
+      logical,                           intent(in)    :: flag_xyfill
+      real(REAL64),                      intent(in)    :: fill_value
       type(hist_log_messages), optional, intent(inout) :: logger
       ! Local variable
       integer :: ind1
@@ -511,14 +502,14 @@ CONTAINS
             nacc = this%num_samples(ind1)
             if (nacc > 0) then
                norm_val(ind1) = this%data(ind1) / nacc
-            else if (this%flag_xyfill) then
-               norm_val(ind1) = this%fill_value
+            else if (flag_xyfill) then
+               norm_val(ind1) = fill_value
             end if
          end do
       else
          ! Standard deviation
          ! from http://www.johndcook.com/blog/standard_deviation/
-         tmpfill = merge(real(this%fill_value, REAL64), 0.0_REAL64, this%flag_xyfill)
+         tmpfill = merge(fill_value, 0.0_REAL64, flag_xyfill)
          do ind1 = 1, size(this%data,1)
             if (this%num_samples(ind1) > 0) then
                variance = this%var_buffer(ind1) / this%num_samples(ind1)
@@ -575,25 +566,21 @@ CONTAINS
    !#######################################################################
 
    subroutine init_buff_2d(this, field_in, volume_in, horiz_axis_in, &
-        accum_type_in, fill_val_in, shape_in, flag_xyfill_in, block_sizes_in, &
-        block_ind_in, logger)
+        accum_type_in, shape_in, block_sizes_in, block_ind_in, logger)
       use hist_msg_handler, only: hist_log_messages
 
-      class(hist_buff_2d_t),       intent(inout) :: this
+      class(hist_buff_2d_t),             intent(inout) :: this
       class(hist_hashable_t),  pointer                 :: field_in
       integer,                           intent(in)    :: volume_in
       integer,                           intent(in)    :: horiz_axis_in
       integer,                           intent(in)    :: accum_type_in
-      real(REAL64),                      intent(in)    :: fill_val_in
       integer,                           intent(in)    :: shape_in(:)
-      logical,                           intent(in)    :: flag_xyfill_in
       integer,                 optional, intent(in)    :: block_sizes_in(:)
       integer,                 optional, intent(in)    :: block_ind_in
       type(hist_log_messages), optional, intent(inout) :: logger
 
       call init_buffer(this, field_in, volume_in, horiz_axis_in, accum_type_in, &
-              fill_val_in, shape_in, flag_xyfill_in, block_sizes_in, &
-              block_ind_in, logger=logger)
+              shape_in, block_sizes_in, block_ind_in, logger=logger)
       call this%clear(logger=logger)
       this%buff_type = 'buff_2d'
 
@@ -601,12 +588,15 @@ CONTAINS
 
    !#######################################################################
 
-   subroutine buff_2d_accum(this, field, cols_or_block, cole, logger)
+   subroutine buff_2d_accum(this, field, cols_or_block, flag_xyfill, &
+         fill_value, cole, logger)
       use hist_msg_handler, only: hist_log_messages
       ! Dummy arguments
       class(hist_buff_2d_t),       intent(inout) :: this
       real(REAL64),                      intent(in)    :: field(:,:)
       integer,                           intent(in)    :: cols_or_block
+      logical,                           intent(in)    :: flag_xyfill
+      real(REAL64),                      intent(in)    :: fill_value
       integer,                 optional, intent(in)    :: cole
       type(hist_log_messages), optional, intent(inout) :: logger
       ! Local variables
@@ -635,31 +625,31 @@ CONTAINS
          do ind1 = col_beg_use, col_end_use
             this%num_samples(ind1) = 0
             ! Only set samples for this column if not a fill value
-            if (this%flag_xyfill .and. field(ind1 - col_beg_use + 1, 1) /= this%fill_value) then
+            if (flag_xyfill .and. field(ind1 - col_beg_use + 1, 1) /= fill_value) then
                this%num_samples(ind1) = 1
             end if
             do ind2 = 1, size(field,2)
                fld_val = field(ind1 - col_beg_use + 1, ind2)
-               if (this%flag_xyfill .and. fld_val == this%fill_value) then
-                  this%data(ind1, ind2) = this%fill_value
+               if (flag_xyfill .and. fld_val == fill_value) then
+                  this%data(ind1, ind2) = fill_value
                else
                   this%data(ind1, ind2) = fld_val
                end if
             end do
          end do
-         if (this%flag_xyfill) then
+         if (flag_xyfill) then
             ! Check if assumption that columns are consistent wrt fill value was accurate
-            call this%check_fill_value(field(col_beg_use:col_end_use, :), logger)
+            call this%check_fill_value(field(col_beg_use:col_end_use, :), fill_value, logger)
          end if
       case (hist_accum_min)
          do ind1 = col_beg_use, col_end_use
             do ind2 = 1, size(field, 2)
                fld_val = field(ind1 - col_beg_use + 1, ind2)
-               if (this%flag_xyfill) then
+               if (flag_xyfill) then
                   ! If the buffer (possibly) contains fill values,
                   ! only check for minimum if not a fill value
                   if (this%num_samples(ind1) == 0) then
-                     if (fld_val /= this%fill_value) then
+                     if (fld_val /= fill_value) then
                         this%data(ind1, ind2) = fld_val
                         this%num_samples(ind1) = 1
                      else
@@ -669,7 +659,7 @@ CONTAINS
                         ! the value will be overwritten to fill_value
                         this%data(ind1, ind2) = HUGE(REAL64)
                      end if
-                  else if (fld_val < this%data(ind1, ind2) .and. fld_val /= this%fill_value) then
+                  else if (fld_val < this%data(ind1, ind2) .and. fld_val /= fill_value) then
                      this%data(ind1, ind2) = fld_val
                      this%num_samples(ind1) = 1
                   end if ! No else, we already have the minimum value for this col
@@ -681,18 +671,18 @@ CONTAINS
                end if
             end do
          end do
-         if (this%flag_xyfill) then
-            call this%check_fill_value(field(col_beg_use:col_end_use, :), logger)
+         if (flag_xyfill) then
+            call this%check_fill_value(field(col_beg_use:col_end_use, :), fill_value, logger)
          end if
       case (hist_accum_max)
          do ind1 = col_beg_use, col_end_use
             do ind2 = 1, size(field, 2)
                fld_val = field(ind1 - col_beg_use + 1, ind2)
-               if (this%flag_xyfill) then
+               if (flag_xyfill) then
                   ! If the buffer (possibly) contains fill values,
                   ! only check for maximum if not a fill value
                   if (this%num_samples(ind1) == 0) then
-                     if (fld_val /= this%fill_value) then
+                     if (fld_val /= fill_value) then
                         this%data(ind1, ind2) = fld_val
                         this%num_samples(ind1) = 1
                      else
@@ -702,7 +692,7 @@ CONTAINS
                         ! the value will be overwritten to fill_value
                         this%data(ind1, ind2) = -HUGE(REAL64)
                      end if
-                  else if (fld_val > this%data(ind1, ind2) .and. fld_val /= this%fill_value) then
+                  else if (fld_val > this%data(ind1, ind2) .and. fld_val /= fill_value) then
                      this%data(ind1, ind2) = fld_val
                      this%num_samples(ind1) = 1
                   end if ! No else, we already have the maximum value for this col
@@ -714,17 +704,17 @@ CONTAINS
                end if
             end do
          end do
-         if (this%flag_xyfill) then
-            call this%check_fill_value(field(col_beg_use:col_end_use, :), logger)
+         if (flag_xyfill) then
+            call this%check_fill_value(field(col_beg_use:col_end_use, :), fill_value, logger)
          end if
       case (hist_accum_avg)
          do ind1 = col_beg_use, col_end_use
             do ind2 = 1, size(field, 2)
                fld_val = field(ind1 - col_beg_use + 1, ind2)
                ! Compute running sum
-               if (this%flag_xyfill) then
+               if (flag_xyfill) then
                   ! Only include sample if it is not the fill value
-                  if (fld_val /= this%fill_value) then
+                  if (fld_val /= fill_value) then
                      this%data(ind1, ind2) = this%data(ind1, ind2) + fld_val
                      this%num_samples(ind1) = this%num_samples(ind1) + 1
                   end if
@@ -734,20 +724,20 @@ CONTAINS
                end if
             end do
          end do
-         if (this%flag_xyfill) then
-            call this%check_fill_value(field(col_beg_use:col_end_use, :), logger)
+         if (flag_xyfill) then
+            call this%check_fill_value(field(col_beg_use:col_end_use, :), fill_value, logger)
          end if
       case (hist_accum_var)
          do ind1 = col_beg_use, col_end_use
-            if (this%flag_xyfill .and. field(ind1 - col_beg_use + 1, 1) == this%fill_value) then
+            if (flag_xyfill .and. field(ind1 - col_beg_use + 1, 1) == fill_value) then
                this%num_samples(ind1) = this%num_samples(ind1)
             else
                this%num_samples(ind1) = this%num_samples(ind1) + 1
             end if
             do ind2 = 1, size(field,2)
                fld_val = field(ind1 - col_beg_use + 1, ind2)
-               if (this%flag_xyfill) then
-                  if (fld_val /= real(this%fill_value, REAL64)) then
+               if (flag_xyfill) then
+                  if (fld_val /= fill_value) then
                      ! Only include the sample if it's not a fill value
                      if (this%num_samples(ind1) == 1) then
                         this%data(ind1, ind2) = fld_val
@@ -778,8 +768,8 @@ CONTAINS
                end if
             end do
          end do
-         if (this%flag_xyfill) then
-            call this%check_fill_value(field(col_beg_use:col_end_use, :), logger)
+         if (flag_xyfill) then
+            call this%check_fill_value(field(col_beg_use:col_end_use, :), fill_value, logger)
          end if
       end select
 
@@ -787,11 +777,12 @@ CONTAINS
 
    !#######################################################################
 
-   subroutine buff_2d_check_fill(this, field, logger)
+   subroutine buff_2d_check_fill(this, field, fill_value, logger)
       use hist_msg_handler, only: hist_log_messages, hist_add_error, ERROR
       ! Ensure that columns have fill value applied consistently across levels
-      class(hist_buff_2d_t),       intent(inout) :: this
+      class(hist_buff_2d_t),             intent(inout) :: this
       real(REAL64),                      intent(in)    :: field(:,:)
+      real(REAL64),                      intent(in)    :: fill_value
       type(hist_log_messages), optional, intent(inout) :: logger
       ! Local variables
       character(len=512) :: errstr
@@ -799,8 +790,8 @@ CONTAINS
 
       do jdx = 2, size(field, 2)
          do idx = 1, size(field, 1)
-            if (field(idx,1) == this%fill_value .and. field(idx,jdx) /= this%fill_value .or. &
-                 field(idx,1) /= this%fill_value .and. field(idx,jdx) == this%fill_value) then
+            if (field(idx,1) == fill_value .and. field(idx,jdx) /= fill_value .or. &
+                 field(idx,1) /= fill_value .and. field(idx,jdx) == fill_value) then
                write(errstr, '(a,i0)') 'ERROR: fill value applied inconsistently for column ', idx
                call hist_add_error('buff_2d_check_fill', errstr, errors=logger)
             end if
@@ -810,11 +801,13 @@ CONTAINS
 
    !#######################################################################
 
-   subroutine buff_2d_value(this, norm_val, logger)
+   subroutine buff_2d_value(this, norm_val, flag_xyfill, fill_value, logger)
       use hist_msg_handler, only: hist_log_messages, ERROR, VERBOSE
       ! Dummy arguments
-      class(hist_buff_2d_t),       intent(inout) :: this
+      class(hist_buff_2d_t),             intent(inout) :: this
       real(REAL64),                      intent(inout) :: norm_val(:,:)
+      logical,                           intent(in)    :: flag_xyfill
+      real(REAL64),                      intent(in)    :: fill_value
       type(hist_log_messages), optional, intent(inout) :: logger
       ! Local variable
       integer :: ind1, ind2
@@ -827,15 +820,15 @@ CONTAINS
                nacc = this%num_samples(ind1)
                if (nacc > 0) then
                   norm_val(ind1, ind2) = this%data(ind1, ind2) / nacc
-               else if (this%flag_xyfill) then
-                  norm_val(ind1, ind2) = this%fill_value
+               else if (flag_xyfill) then
+                  norm_val(ind1, ind2) = fill_value
                end if
             end do
          end do
       else
          ! Standard deviation
          ! from http://www.johndcook.com/blog/standard_deviation/
-         tmpfill = merge(real(this%fill_value, REAL64), 0.0_REAL64, this%flag_xyfill)
+         tmpfill = merge(fill_value, 0.0_REAL64, flag_xyfill)
          do ind1 = 1, size(this%data,1)
             do ind2 = 1, size(this%data,2)
                if (this%num_samples(ind1) > 0) then

--- a/src/hist_buffer.F90
+++ b/src/hist_buffer.F90
@@ -56,6 +56,7 @@ module hist_buffer
 
    type, public, extends(hist_buffer_t) :: hist_buff_1dreal32_t
       real(REAL32), pointer :: data(:) => NULL()
+      real(REAL32), pointer :: var_buffer(:) => NULL()
       integer,  allocatable,   private :: num_samples(:)
    CONTAINS
       procedure :: clear => buff_1dreal32_clear
@@ -66,7 +67,8 @@ module hist_buffer
 
    type, public, extends(hist_buffer_t) :: hist_buff_2dreal32_t
       real(REAL32), pointer :: data(:,:) => NULL()
-      integer,  allocatable,   private :: num_samples(:,:)
+      real(REAL32), pointer :: var_buffer(:,:) => NULL()
+      integer,  allocatable,   private :: num_samples(:)
    CONTAINS
       procedure :: clear => buff_2dreal32_clear
       procedure :: accumulate => buff_2dreal32_accum
@@ -77,6 +79,7 @@ module hist_buffer
 
    type, public, extends(hist_buffer_t) :: hist_buff_1dreal64_t
       real(REAL64), pointer :: data(:) => NULL()
+      real(REAL32), pointer :: var_buffer(:) => NULL()
       integer,  allocatable,   private :: num_samples(:)
    CONTAINS
       procedure :: clear => buff_1dreal64_clear
@@ -87,7 +90,8 @@ module hist_buffer
 
    type, public, extends(hist_buffer_t) :: hist_buff_2dreal64_t
       real(REAL64), pointer :: data(:,:) => NULL()
-      integer, allocatable,    private :: num_samples(:,:)
+      real(REAL32), pointer :: var_buffer(:,:) => NULL()
+      integer, allocatable,    private :: num_samples(:)
    CONTAINS
       procedure :: clear => buff_2dreal64_clear
       procedure :: accumulate => buff_2dreal64_accum
@@ -302,6 +306,13 @@ CONTAINS
                  subname=subname, errors=logger)
          end if
       end if
+      if (.not. associated(this%var_buffer) .and. this%accum_type == hist_accum_var) then
+         allocate(this%var_buffer(this%field_shape(1)), stat=aerr)
+         if (aerr /= 0) then
+            call hist_add_alloc_error('var_buffer', __FILE__, __LINE__ - 2,         &
+                 subname=subname, errors=logger)
+         end if
+      end if
       if (.not. allocated(this%num_samples)) then
          allocate(this%num_samples(this%field_shape(1)), stat=aerr)
          if (aerr /= 0) then
@@ -311,6 +322,9 @@ CONTAINS
       end if
       this%data = 0.0_REAL32
       this%num_samples = 0
+      if (associated(this%var_buffer)) then
+         this%var_buffer = 0.0_REAL32
+      end if
 
    end subroutine buff_1dreal32_clear
 
@@ -360,8 +374,15 @@ CONTAINS
                  subname=subname, errors=logger)
          end if
       end if
+      if (.not. associated(this%var_buffer) .and. this%accum_type == hist_accum_var) then
+         allocate(this%var_buffer(this%field_shape(1), this%field_shape(2)), stat=aerr)
+         if (aerr /= 0) then
+            call hist_add_alloc_error('var_buffer', __FILE__, __LINE__ - 2,         &
+                 subname=subname, errors=logger)
+         end if
+      end if
       if (.not. allocated(this%num_samples)) then
-         allocate(this%num_samples(this%field_shape(1), this%field_shape(2)), stat=aerr)
+         allocate(this%num_samples(this%field_shape(1)), stat=aerr)
          if (aerr /= 0) then
             call hist_add_alloc_error('num_samples', __FILE__, __LINE__ - 2,         &
                  subname=subname, errors=logger)
@@ -369,6 +390,9 @@ CONTAINS
       end if
       this%data = 0.0_REAL32
       this%num_samples = 0
+      if (associated(this%var_buffer)) then
+         this%var_buffer = 0.0_REAL32
+      end if
 
    end subroutine buff_2dreal32_clear
 
@@ -384,17 +408,34 @@ CONTAINS
       ! Local variable
       integer :: ind1, ind2
       integer :: nacc
+      real(REAL32) :: tmpfill, variance
 
-      do ind1 = 1, size(this%data,1)
-         do ind2 = 1, size(this%data,2)
-            nacc = this%num_samples(ind1, ind2)
-            if (nacc > 0) then
-               norm_val(ind1, ind2) = this%data(ind1, ind2) / nacc
-            else if (this%flag_xyfill) then
-               norm_val(ind1, ind2) = this%fill_value
-            end if
+      if (this%accum_type /= hist_accum_var) then
+         do ind1 = 1, size(this%data,1)
+            nacc = this%num_samples(ind1)
+            do ind2 = 1, size(this%data,2)
+               if (nacc > 0) then
+                  norm_val(ind1, ind2) = this%data(ind1, ind2) / nacc
+               else if (this%flag_xyfill) then
+                  norm_val(ind1, ind2) = this%fill_value
+               end if
+            end do
          end do
-      end do
+      else
+         ! Standard deviation
+         ! from http://www.johndcook.com/blog/standard_deviation/
+         tmpfill = merge(real(this%fill_value, REAL32), 0.0_REAL32, this%flag_xyfill)
+         do ind1 = 1, size(this%data,1)
+            do ind2 = 1, size(this%data,2)
+               if (this%num_samples(ind1) > 0) then
+                  variance = this%var_buffer(ind1, ind2) / this%num_samples(ind1)
+                  norm_val(ind1, ind2) = sqrt(variance)
+               else
+                  norm_val(ind1, ind2) = tmpfill
+               end if
+            end do
+         end do
+      end if
 
    end subroutine buff_2dreal32_value
 
@@ -412,7 +453,7 @@ CONTAINS
       integer      :: col_beg_use
       integer      :: col_end_use
       integer      :: ind1, ind2
-      real(REAL32) :: fld_val
+      real(REAL32) :: fld_val, tmp
 
       if (this%has_blocks()) then
          ! For a blocked field, <cols_or_block> is a block index
@@ -438,10 +479,10 @@ CONTAINS
                   ! Set num samples to 0 if this is a fill value
                   ! This will trigger logic in _value routine
                   this%data(ind1, ind2) = this%fill_value
-                  this%num_samples(ind1, ind2) = 0
+                  this%num_samples(ind1) = 0
                else
                   this%data(ind1, ind2) = fld_val
-                  this%num_samples(ind1, ind2) = 1
+                  this%num_samples(ind1) = 1
                end if
             end do
          end do
@@ -452,10 +493,10 @@ CONTAINS
                if (this%flag_xyfill) then
                   ! If the buffer (possibly) contains fill values,
                   ! only check for minimum if not a fill value
-                  if (this%num_samples(ind1, ind2) == 0) then
+                  if (this%num_samples(ind1) == 0) then
                      if (fld_val /= this%fill_value) then
                         this%data(ind1, ind2) = fld_val
-                        this%num_samples(ind1, ind2) = 1
+                        this%num_samples(ind1) = 1
                      else
                         ! Set to large positive number if this is a fill value
                         ! Also do not change num_samples - if num_samples
@@ -465,12 +506,12 @@ CONTAINS
                      end if
                   else if (fld_val < this%data(ind1, ind2) .and. fld_val /= this%fill_value) then
                      this%data(ind1, ind2) = fld_val
-                     this%num_samples(ind1, ind2) = 1
+                     this%num_samples(ind1) = 1
                   end if ! No else, we already have the minimum value for this col
                else
-                  if (this%num_samples(ind1, ind2) == 0 .or. fld_val < this%data(ind1, ind2)) then
+                  if (this%num_samples(ind1) == 0 .or. fld_val < this%data(ind1, ind2)) then
                      this%data(ind1, ind2) = fld_val
-                     this%num_samples(ind1, ind2) = 1
+                     this%num_samples(ind1) = 1
                   end if ! No else, we already have the minimum value for this col
                end if
             end do
@@ -485,10 +526,10 @@ CONTAINS
                if (this%flag_xyfill) then
                   ! If the buffer (possibly) contains fill values,
                   ! only check for maximum if not a fill value
-                  if (this%num_samples(ind1, ind2) == 0) then
+                  if (this%num_samples(ind1) == 0) then
                      if (fld_val /= this%fill_value) then
                         this%data(ind1, ind2) = fld_val
-                        this%num_samples(ind1, ind2) = 1
+                        this%num_samples(ind1) = 1
                      else
                         ! Set to large negative number if this is a fill value
                         ! Also do not change num_samples - if num_samples
@@ -498,12 +539,12 @@ CONTAINS
                      end if
                   else if (fld_val > this%data(ind1, ind2) .and. fld_val /= this%fill_value) then
                      this%data(ind1, ind2) = fld_val
-                     this%num_samples(ind1, ind2) = 1
+                     this%num_samples(ind1) = 1
                   end if ! No else, we already have the maximum value for this col
                else
-                  if (this%num_samples(ind1, ind2) == 0 .or. fld_val > this%data(ind1, ind2)) then
+                  if (this%num_samples(ind1) == 0 .or. fld_val > this%data(ind1, ind2)) then
                      this%data(ind1, ind2) = fld_val
-                     this%num_samples(ind1, ind2) = 1
+                     this%num_samples(ind1) = 1
                   end if ! No else, we already have the maximum value for this col
                end if
             end do
@@ -520,11 +561,54 @@ CONTAINS
                   ! Only include sample if it's not a fill value
                   if (fld_val /= real(this%fill_value, REAL32)) then
                      this%data(ind1, ind2) = this%data(ind1, ind2) + fld_val
-                     this%num_samples(ind1, ind2) = this%num_samples(ind1, ind2) + 1
+                     this%num_samples(ind1) = this%num_samples(ind1) + 1
                   end if
                else
                   this%data(ind1, ind2) = this%data(ind1, ind2) + fld_val
-                  this%num_samples(ind1, ind2) = this%num_samples(ind1, ind2) + 1
+                  this%num_samples(ind1) = this%num_samples(ind1) + 1
+               end if
+            end do
+         end do
+         if (this%flag_xyfill) then
+            call this%check_fill_value(field(col_beg_use:col_end_use, :), logger)
+         end if
+      case (hist_accum_var)
+         do ind1 = col_beg_use, col_end_use
+            do ind2 = 1, size(field,2)
+               fld_val = field(ind1 - col_beg_use + 1, ind2)
+               if (this%flag_xyfill) then
+                  if (fld_val /= real(this%fill_value, REAL32)) then
+                     ! Only include the sample if it's not a fill value
+                     if (this%num_samples(ind1) == 0) then
+                        this%data(ind1, ind2) = fld_val
+                        this%var_buffer(ind1, ind2) = 0._REAL32
+                        this%num_samples(ind1) = this%num_samples(ind1) + 1
+                     else
+                        tmp = this%data(ind1, ind2)
+                        this%num_samples(ind1) = this%num_samples(ind1) + 1
+                        this%data(ind1, ind2) = this%data(ind1, ind2) + &
+                                (fld_val - this%data(ind1, ind2)) / &
+                                this%num_samples(ind1)
+                        this%var_buffer(ind1, ind2) = this%var_buffer(ind1, ind2) + &
+                                (fld_val - this%data(ind1, ind2)) * &
+                                (fld_val - tmp)
+                     end if
+                  end if
+               else
+                  if (this%num_samples(ind1) == 0) then
+                     this%data(ind1, ind2) = fld_val
+                     this%var_buffer(ind1, ind2) = 0._REAL32
+                     this%num_samples(ind1) = this%num_samples(ind1) + 1
+                  else
+                     tmp = this%data(ind1, ind2)
+                     this%num_samples(ind1) = this%num_samples(ind1) + 1
+                     this%data(ind1, ind2) = this%data(ind1, ind2) + &
+                             (fld_val - this%data(ind1, ind2)) / &
+                             this%num_samples(ind1)
+                     this%var_buffer(ind1, ind2) = this%var_buffer(ind1, ind2) + &
+                             (fld_val - this%data(ind1, ind2)) * &
+                             (fld_val - tmp)
+                  end if
                end if
             end do
          end do
@@ -574,7 +658,7 @@ CONTAINS
       integer      :: col_beg_use
       integer      :: col_end_use
       integer      :: ind1
-      real(REAL32) :: fld_val
+      real(REAL32) :: fld_val, tmp
 
       if (this%has_blocks()) then
          ! For a blocked field, <cols_or_block> is a block index
@@ -675,6 +759,44 @@ CONTAINS
                this%num_samples(ind1) = this%num_samples(ind1) + 1
             end if
          end do
+      case (hist_accum_var)
+         do ind1 = col_beg_use, col_end_use
+            fld_val = field(ind1 - col_beg_use + 1)
+            if (this%flag_xyfill) then
+               if (fld_val /= real(this%fill_value, REAL32)) then
+                  ! Only include the sample if it's not a fill value
+                  if (this%num_samples(ind1) == 0) then
+                     this%data(ind1) = fld_val
+                     this%var_buffer(ind1) = 0._REAL32
+                     this%num_samples(ind1) = this%num_samples(ind1) + 1
+                  else
+                     tmp = this%data(ind1)
+                     this%num_samples(ind1) = this%num_samples(ind1) + 1
+                     this%data(ind1) = this%data(ind1) + &
+                             (fld_val - this%data(ind1)) / &
+                             this%num_samples(ind1)
+                     this%var_buffer(ind1) = this%var_buffer(ind1) + &
+                             (fld_val - this%data(ind1)) * &
+                             (fld_val - tmp)
+                  end if
+               end if
+            else
+               if (this%num_samples(ind1) == 0) then
+                  this%data(ind1) = fld_val
+                  this%var_buffer(ind1) = 0._REAL32
+                  this%num_samples(ind1) = this%num_samples(ind1) + 1
+               else
+                  tmp = this%data(ind1)
+                  this%num_samples(ind1) = this%num_samples(ind1) + 1
+                  this%data(ind1) = this%data(ind1) + &
+                          (fld_val - this%data(ind1)) / &
+                          this%num_samples(ind1)
+                  this%var_buffer(ind1) = this%var_buffer(ind1) + &
+                          (fld_val - this%data(ind1)) * &
+                          (fld_val - tmp)
+               end if
+            end if
+         end do
       end select
 
    end subroutine buff_1dreal32_accum
@@ -691,15 +813,31 @@ CONTAINS
       ! Local variable
       integer :: ind1
       integer :: nacc
+      real(REAL32) :: tmpfill, variance
 
-      do ind1 = 1, size(this%data,1)
-         nacc = this%num_samples(ind1)
-         if (nacc > 0) then
-            norm_val(ind1) = this%data(ind1) / nacc
-         else if (this%flag_xyfill) then
-            norm_val(ind1) = this%fill_value
-         end if
-      end do
+      if (this%accum_type /= hist_accum_var) then
+         do ind1 = 1, size(this%data,1)
+            nacc = this%num_samples(ind1)
+            if (nacc > 0) then
+               norm_val(ind1) = this%data(ind1) / nacc
+            else if (this%flag_xyfill) then
+               norm_val(ind1) = this%fill_value
+            end if
+         end do
+      else
+         ! Standard deviation
+         ! from http://www.johndcook.com/blog/standard_deviation/
+         tmpfill = merge(real(this%fill_value, REAL32), 0.0_REAL32, this%flag_xyfill)
+         do ind1 = 1, size(this%data,1)
+            if (this%num_samples(ind1) > 0) then
+               variance = this%var_buffer(ind1) / this%num_samples(ind1)
+               norm_val(ind1) = sqrt(variance)
+            else
+               norm_val(ind1) = tmpfill
+            end if
+         end do
+      end if
+
 
    end subroutine buff_1dreal32_value
 
@@ -722,6 +860,13 @@ CONTAINS
                  subname=subname, errors=logger)
          end if
       end if
+      if (.not. associated(this%var_buffer) .and. this%accum_type == hist_accum_var) then
+         allocate(this%var_buffer(this%field_shape(1)), stat=aerr)
+         if (aerr /= 0) then
+            call hist_add_alloc_error('var_buffer', __FILE__, __LINE__ - 2,         &
+                 subname=subname, errors=logger)
+         end if
+      end if
       if (.not. allocated(this%num_samples)) then
          allocate(this%num_samples(this%field_shape(1)), stat=aerr)
          if (aerr /= 0) then
@@ -731,6 +876,9 @@ CONTAINS
       end if
       this%data = 0.0_REAL64
       this%num_samples = 0
+      if (associated(this%var_buffer)) then
+         this%var_buffer = 0.0_REAL64
+      end if
 
    end subroutine buff_1dreal64_clear
 
@@ -775,7 +923,7 @@ CONTAINS
       integer      :: col_beg_use
       integer      :: col_end_use
       integer      :: ind1
-      real(REAL64) :: fld_val
+      real(REAL64) :: fld_val, tmp
 
       if (this%has_blocks()) then
          col_end_use = this%block_ends(cols_or_block)
@@ -880,6 +1028,44 @@ CONTAINS
                this%num_samples(ind1) = this%num_samples(ind1) + 1
             end if
          end do
+      case (hist_accum_var)
+         do ind1 = col_beg_use, col_end_use
+            fld_val = field(ind1 - col_beg_use + 1)
+            if (this%flag_xyfill) then
+               if (fld_val /= real(this%fill_value, REAL64)) then
+                  ! Only include the sample if it's not a fill value
+                  if (this%num_samples(ind1) == 0) then
+                     this%data(ind1) = fld_val
+                     this%var_buffer(ind1) = 0._REAL64
+                     this%num_samples(ind1) = this%num_samples(ind1) + 1
+                  else
+                     tmp = this%data(ind1)
+                     this%num_samples(ind1) = this%num_samples(ind1) + 1
+                     this%data(ind1) = this%data(ind1) + &
+                             (fld_val - this%data(ind1)) / &
+                             this%num_samples(ind1)
+                     this%var_buffer(ind1) = this%var_buffer(ind1) + &
+                             (fld_val - this%data(ind1)) * &
+                             (fld_val - tmp)
+                  end if
+               end if
+            else
+               if (this%num_samples(ind1) == 0) then
+                  this%data(ind1) = fld_val
+                  this%var_buffer(ind1) = 0._REAL64
+                  this%num_samples(ind1) = this%num_samples(ind1) + 1
+               else
+                  tmp = this%data(ind1)
+                  this%num_samples(ind1) = this%num_samples(ind1) + 1
+                  this%data(ind1) = this%data(ind1) + &
+                          (fld_val - this%data(ind1)) / &
+                          this%num_samples(ind1)
+                  this%var_buffer(ind1) = this%var_buffer(ind1) + &
+                          (fld_val - this%data(ind1)) * &
+                          (fld_val - tmp)
+               end if
+            end if
+         end do
       end select
 
    end subroutine buff_1dreal64_accum
@@ -895,15 +1081,30 @@ CONTAINS
       ! Local variable
       integer :: ind1
       integer :: nacc
+      real(REAL64) :: tmpfill, variance
 
-      do ind1 = 1, this%field_shape(1)
-         nacc = this%num_samples(ind1)
-         if (nacc > 0) then
-            norm_val(ind1) = this%data(ind1) / nacc
-         else if (this%flag_xyfill) then
-            norm_val(ind1) = this%fill_value
-         end if
-      end do
+      if (this%accum_type /= hist_accum_var) then
+         do ind1 = 1, this%field_shape(1)
+            nacc = this%num_samples(ind1)
+            if (nacc > 0) then
+               norm_val(ind1) = this%data(ind1) / nacc
+            else if (this%flag_xyfill) then
+               norm_val(ind1) = this%fill_value
+            end if
+         end do
+      else
+         ! Standard deviation
+         ! from http://www.johndcook.com/blog/standard_deviation/
+         tmpfill = merge(real(this%fill_value, REAL64), 0.0_REAL64, this%flag_xyfill)
+         do ind1 = 1, size(this%data,1)
+            if (this%num_samples(ind1) > 0) then
+               variance = this%var_buffer(ind1) / this%num_samples(ind1)
+               norm_val(ind1) = sqrt(variance)
+            else
+               norm_val(ind1) = tmpfill
+            end if
+         end do
+      end if
 
    end subroutine buff_1dreal64_value
 
@@ -926,8 +1127,15 @@ CONTAINS
                  subname=subname, errors=logger)
          end if
       end if
+      if (.not. associated(this%var_buffer) .and. this%accum_type == hist_accum_var) then
+         allocate(this%var_buffer(this%field_shape(1), this%field_shape(2)), stat=aerr)
+         if (aerr /= 0) then
+            call hist_add_alloc_error('var_buffer', __FILE__, __LINE__ - 2,         &
+                 subname=subname, errors=logger)
+         end if
+      end if
       if (.not. allocated(this%num_samples)) then
-         allocate(this%num_samples(this%field_shape(1), this%field_shape(2)), stat=aerr)
+         allocate(this%num_samples(this%field_shape(1)), stat=aerr)
          if (aerr /= 0) then
             call hist_add_alloc_error('num_samples', __FILE__, __LINE__ - 1,         &
                  subname=subname, errors=logger)
@@ -935,6 +1143,9 @@ CONTAINS
       end if
       this%data = 0.0_REAL64
       this%num_samples = 0
+      if (associated(this%var_buffer)) then
+         this%var_buffer = 0.0_REAL64
+      end if
 
    end subroutine buff_2dreal64_clear
 
@@ -979,7 +1190,7 @@ CONTAINS
       integer      :: col_beg_use
       integer      :: col_end_use
       integer      :: ind1, ind2
-      real(REAL64) :: fld_val
+      real(REAL64) :: fld_val, tmp
 
       if (this%has_blocks()) then
          ! For a blocked field, <cols_or_block> is a block index
@@ -1005,10 +1216,10 @@ CONTAINS
                   ! Set num samples to 0 if this is a fill value
                   ! This will trigger logic in _value routine
                   this%data(ind1, ind2) = this%fill_value
-                  this%num_samples = 0
+                  this%num_samples(ind1) = 0
                else
                   this%data(ind1, ind2) = fld_val
-                  this%num_samples = 1
+                  this%num_samples(ind1) = 1
                end if
             end do
          end do
@@ -1019,10 +1230,10 @@ CONTAINS
                if (this%flag_xyfill) then
                   ! If the buffer (possibly) contains fill values,
                   ! only check for minimum if not a fill value
-                  if (this%num_samples(ind1, ind2) == 0) then
+                  if (this%num_samples(ind1) == 0) then
                      if (fld_val /= this%fill_value) then
                         this%data(ind1, ind2) = fld_val
-                        this%num_samples(ind1, ind2) = 1
+                        this%num_samples(ind1) = 1
                      else
                         ! Set to large positive number if this is a fill value
                         ! Also do not change num_samples - if num_samples
@@ -1032,12 +1243,12 @@ CONTAINS
                      end if
                   else if (fld_val < this%data(ind1, ind2) .and. fld_val /= this%fill_value) then
                      this%data(ind1, ind2) = fld_val
-                     this%num_samples(ind1, ind2) = 1
+                     this%num_samples(ind1) = 1
                   end if ! No else, we already have the minimum value for this col
                else
-                  if (this%num_samples(ind1, ind2) == 0 .or. fld_val < this%data(ind1, ind2)) then
+                  if (this%num_samples(ind1) == 0 .or. fld_val < this%data(ind1, ind2)) then
                      this%data(ind1, ind2) = fld_val
-                     this%num_samples(ind1, ind2) = 1
+                     this%num_samples(ind1) = 1
                   end if ! No else, we already have the minimum value for this col
                end if
             end do
@@ -1052,10 +1263,10 @@ CONTAINS
                if (this%flag_xyfill) then
                   ! If the buffer (possibly) contains fill values,
                   ! only check for maximum if not a fill value
-                  if (this%num_samples(ind1, ind2) == 0) then
+                  if (this%num_samples(ind1) == 0) then
                      if (fld_val /= this%fill_value) then
                         this%data(ind1, ind2) = fld_val
-                        this%num_samples(ind1, ind2) = 1
+                        this%num_samples(ind1) = 1
                      else
                         ! Set to large negative number if this is a fill value
                         ! Also do not change num_samples - if num_samples
@@ -1065,12 +1276,12 @@ CONTAINS
                      end if
                   else if (fld_val > this%data(ind1, ind2) .and. fld_val /= this%fill_value) then
                      this%data(ind1, ind2) = fld_val
-                     this%num_samples(ind1, ind2) = 1
+                     this%num_samples(ind1) = 1
                   end if ! No else, we already have the maximum value for this col
                else
-                  if (this%num_samples(ind1, ind2) == 0 .or. fld_val > this%data(ind1, ind2)) then
+                  if (this%num_samples(ind1) == 0 .or. fld_val > this%data(ind1, ind2)) then
                      this%data(ind1, ind2) = fld_val
-                     this%num_samples(ind1, ind2) = 1
+                     this%num_samples(ind1) = 1
                   end if
                end if
             end do
@@ -1087,11 +1298,54 @@ CONTAINS
                   ! Only include sample if it is not the fill value
                   if (fld_val /= this%fill_value) then
                      this%data(ind1, ind2) = this%data(ind1, ind2) + fld_val
-                     this%num_samples(ind1, ind2) = this%num_samples(ind1, ind2) + 1
+                     this%num_samples(ind1) = this%num_samples(ind1) + 1
                   end if
                else
                   this%data(ind1, ind2) = this%data(ind1, ind2) + fld_val
-                  this%num_samples(ind1, ind2) = this%num_samples(ind1, ind2) + 1
+                  this%num_samples(ind1) = this%num_samples(ind1) + 1
+               end if
+            end do
+         end do
+         if (this%flag_xyfill) then
+            call this%check_fill_value(field(col_beg_use:col_end_use, :), logger)
+         end if
+      case (hist_accum_var)
+         do ind1 = col_beg_use, col_end_use
+            do ind2 = 1, size(field,2)
+               fld_val = field(ind1 - col_beg_use + 1, ind2)
+               if (this%flag_xyfill) then
+                  if (fld_val /= real(this%fill_value, REAL64)) then
+                     ! Only include the sample if it's not a fill value
+                     if (this%num_samples(ind1) == 0) then
+                        this%data(ind1, ind2) = fld_val
+                        this%var_buffer(ind1, ind2) = 0._REAL64
+                        this%num_samples(ind1) = this%num_samples(ind1) + 1
+                     else
+                        tmp = this%data(ind1, ind2)
+                        this%num_samples(ind1) = this%num_samples(ind1) + 1
+                        this%data(ind1, ind2) = this%data(ind1, ind2) + &
+                                (fld_val - this%data(ind1, ind2)) / &
+                                this%num_samples(ind1)
+                        this%var_buffer(ind1, ind2) = this%var_buffer(ind1, ind2) + &
+                                (fld_val - this%data(ind1, ind2)) * &
+                                (fld_val - tmp)
+                     end if
+                  end if
+               else
+                  if (this%num_samples(ind1) == 0) then
+                     this%data(ind1, ind2) = fld_val
+                     this%var_buffer(ind1, ind2) = 0._REAL64
+                     this%num_samples(ind1) = this%num_samples(ind1) + 1
+                  else
+                     tmp = this%data(ind1, ind2)
+                     this%num_samples(ind1) = this%num_samples(ind1) + 1
+                     this%data(ind1, ind2) = this%data(ind1, ind2) + &
+                             (fld_val - this%data(ind1, ind2)) / &
+                             this%num_samples(ind1)
+                     this%var_buffer(ind1, ind2) = this%var_buffer(ind1, ind2) + &
+                             (fld_val - this%data(ind1, ind2)) * &
+                             (fld_val - tmp)
+                  end if
                end if
             end do
          end do
@@ -1136,17 +1390,34 @@ CONTAINS
       ! Local variable
       integer :: ind1, ind2
       integer :: nacc
+      real(REAL64) :: tmpfill, variance
 
-      do ind1 = 1, this%field_shape(1)
-         do ind2 = 1, this%field_shape(2)
-            nacc = this%num_samples(ind1,ind2)
-            if (nacc > 0) then
-               norm_val(ind1, ind2) = this%data(ind1, ind2) / nacc
-            else if (this%flag_xyfill) then
-               norm_val(ind1, ind2) = this%fill_value
-            end if
+      if (this%accum_type /= hist_accum_var) then
+         do ind1 = 1, this%field_shape(1)
+            do ind2 = 1, this%field_shape(2)
+               nacc = this%num_samples(ind1)
+               if (nacc > 0) then
+                  norm_val(ind1, ind2) = this%data(ind1, ind2) / nacc
+               else if (this%flag_xyfill) then
+                  norm_val(ind1, ind2) = this%fill_value
+               end if
+            end do
          end do
-      end do
+      else
+         ! Standard deviation
+         ! from http://www.johndcook.com/blog/standard_deviation/
+         tmpfill = merge(real(this%fill_value, REAL64), 0.0_REAL64, this%flag_xyfill)
+         do ind1 = 1, size(this%data,1)
+            do ind2 = 1, size(this%data,2)
+               if (this%num_samples(ind1) > 0) then
+                  variance = this%var_buffer(ind1, ind2) / this%num_samples(ind1)
+                  norm_val(ind1, ind2) = sqrt(variance)
+               else
+                  norm_val(ind1, ind2) = tmpfill
+               end if
+            end do
+         end do
+      end if
 
    end subroutine buff_2dreal64_value
 

--- a/src/hist_buffer.F90
+++ b/src/hist_buffer.F90
@@ -374,7 +374,7 @@ CONTAINS
          do ind2 = 1, size(this%data,2)
             nacc = this%num_samples(ind1, ind2)
             if (nacc > 0) then
-               norm_val(ind1, ind2) = this%data(ind1, ind2)
+               norm_val(ind1, ind2) = this%data(ind1, ind2) / nacc
             else if (present(default_val)) then
                norm_val(ind1, ind2) = default_val
             end if
@@ -538,7 +538,7 @@ CONTAINS
       do ind1 = 1, size(this%data,1)
          nacc = this%num_samples(ind1)
          if (nacc > 0) then
-            norm_val(ind1) = this%data(ind1)
+            norm_val(ind1) = this%data(ind1) / nacc
          else if (present(default_val)) then
             norm_val(ind1) = default_val
          end if
@@ -681,13 +681,11 @@ CONTAINS
       do ind1 = 1, this%field_shape(1)
          nacc = this%num_samples(ind1)
          if (nacc > 0) then
-            norm_val(ind1) = this%data(ind1)
+            norm_val(ind1) = this%data(ind1) / nacc
          else if (present(default_val)) then
             norm_val(ind1) = default_val
          end if
       end do
-
-      norm_val(:) = this%data(:)
 
    end subroutine buff_1dreal64_value
 
@@ -836,7 +834,7 @@ CONTAINS
          do ind2 = 1, this%field_shape(2)
             nacc = this%num_samples(ind1,ind2)
             if (nacc > 0) then
-               norm_val(ind1, ind2) = this%data(ind1, ind2)
+               norm_val(ind1, ind2) = this%data(ind1, ind2) / nacc
             else if (present(default_val)) then
                norm_val(ind1, ind2) = default_val
             end if

--- a/src/hist_buffer.F90
+++ b/src/hist_buffer.F90
@@ -1,5 +1,5 @@
 module hist_buffer
-   use ISO_FORTRAN_ENV, only: REAL64, REAL32, INT32, INT64
+   use ISO_FORTRAN_ENV, only: REAL64, INT32, INT64
    use hist_hashable,   only: hist_hashable_t
 
    implicit none
@@ -54,51 +54,28 @@ module hist_buffer
       procedure(hist_buff_init),    deferred :: initialize
    end type hist_buffer_t
 
-   type, public, extends(hist_buffer_t) :: hist_buff_1dreal32_t
-      real(REAL32), pointer :: data(:) => NULL()
-      real(REAL32), pointer :: var_buffer(:) => NULL()
-      integer,  allocatable,   private :: num_samples(:)
-   CONTAINS
-      procedure :: clear => buff_1dreal32_clear
-      procedure :: accumulate => buff_1dreal32_accum
-      procedure :: norm_value => buff_1dreal32_value
-      procedure :: initialize => init_buff_1dreal32
-   end type hist_buff_1dreal32_t
-
-   type, public, extends(hist_buffer_t) :: hist_buff_2dreal32_t
-      real(REAL32), pointer :: data(:,:) => NULL()
-      real(REAL32), pointer :: var_buffer(:,:) => NULL()
-      integer,  allocatable,   private :: num_samples(:)
-   CONTAINS
-      procedure :: clear => buff_2dreal32_clear
-      procedure :: accumulate => buff_2dreal32_accum
-      procedure :: norm_value => buff_2dreal32_value
-      procedure :: initialize => init_buff_2dreal32
-      procedure :: check_fill_value => buff_2dreal32_check_fill
-   end type hist_buff_2dreal32_t
-
-   type, public, extends(hist_buffer_t) :: hist_buff_1dreal64_t
+   type, public, extends(hist_buffer_t) :: hist_buff_1d_t
       real(REAL64), pointer :: data(:) => NULL()
-      real(REAL32), pointer :: var_buffer(:) => NULL()
+      real(REAL64), pointer :: var_buffer(:) => NULL()
       integer,  allocatable,   private :: num_samples(:)
    CONTAINS
-      procedure :: clear => buff_1dreal64_clear
-      procedure :: accumulate => buff_1dreal64_accum
-      procedure :: norm_value => buff_1dreal64_value
-      procedure :: initialize => init_buff_1dreal64
-   end type hist_buff_1dreal64_t
+      procedure :: clear => buff_1d_clear
+      procedure :: accumulate => buff_1d_accum
+      procedure :: norm_value => buff_1d_value
+      procedure :: initialize => init_buff_1d
+   end type hist_buff_1d_t
 
-   type, public, extends(hist_buffer_t) :: hist_buff_2dreal64_t
+   type, public, extends(hist_buffer_t) :: hist_buff_2d_t
       real(REAL64), pointer :: data(:,:) => NULL()
-      real(REAL32), pointer :: var_buffer(:,:) => NULL()
+      real(REAL64), pointer :: var_buffer(:,:) => NULL()
       integer, allocatable,    private :: num_samples(:)
    CONTAINS
-      procedure :: clear => buff_2dreal64_clear
-      procedure :: accumulate => buff_2dreal64_accum
-      procedure :: norm_value => buff_2dreal64_value
-      procedure :: initialize => init_buff_2dreal64
-      procedure :: check_fill_value => buff_2dreal64_check_fill
-   end type hist_buff_2dreal64_t
+      procedure :: clear => buff_2d_clear
+      procedure :: accumulate => buff_2d_accum
+      procedure :: norm_value => buff_2d_value
+      procedure :: initialize => init_buff_2d
+      procedure :: check_fill_value => buff_2d_check_fill
+   end type hist_buff_2d_t
 
    ! Abstract interfaces for hist_buffer_t class
    abstract interface
@@ -289,570 +266,15 @@ CONTAINS
 
    !#######################################################################
 
-   subroutine buff_1dreal32_clear(this, logger)
+   subroutine buff_1d_clear(this, logger)
       use hist_msg_handler, only: hist_log_messages, hist_add_alloc_error
 
       ! Dummy arguments
-      class(hist_buff_1dreal32_t),       intent(inout) :: this
+      class(hist_buff_1d_t),       intent(inout) :: this
       type(hist_log_messages), optional, intent(inout) :: logger
       ! Local variables
       integer                     :: aerr
-      character(len=*), parameter :: subname = 'buff_1dreal32_clear'
-
-      if (.not. associated(this%data)) then
-         allocate(this%data(this%field_shape(1)), stat=aerr)
-         if (aerr /= 0) then
-            call hist_add_alloc_error('data', __FILE__, __LINE__ - 2,         &
-                 subname=subname, errors=logger)
-         end if
-      end if
-      if (.not. associated(this%var_buffer) .and. this%accum_type == hist_accum_var) then
-         allocate(this%var_buffer(this%field_shape(1)), stat=aerr)
-         if (aerr /= 0) then
-            call hist_add_alloc_error('var_buffer', __FILE__, __LINE__ - 2,         &
-                 subname=subname, errors=logger)
-         end if
-      end if
-      if (.not. allocated(this%num_samples)) then
-         allocate(this%num_samples(this%field_shape(1)), stat=aerr)
-         if (aerr /= 0) then
-            call hist_add_alloc_error('num_samples', __FILE__, __LINE__ - 2,         &
-                 subname=subname, errors=logger)
-         end if
-      end if
-      this%data = 0.0_REAL32
-      this%num_samples = 0
-      if (associated(this%var_buffer)) then
-         this%var_buffer = 0.0_REAL32
-      end if
-
-   end subroutine buff_1dreal32_clear
-
-   !#######################################################################
-
-   subroutine init_buff_1dreal32(this, field_in, volume_in, horiz_axis_in, &
-        accum_type_in, fill_val_in, shape_in, flag_xyfill_in, block_sizes_in, &
-        block_ind_in, logger)
-      use hist_msg_handler, only: hist_log_messages, hist_add_alloc_error
-
-      ! Dummy arguments
-      class(hist_buff_1dreal32_t),       intent(inout) :: this
-      class(hist_hashable_t),  pointer                 :: field_in
-      integer,                           intent(in)    :: volume_in
-      integer,                           intent(in)    :: horiz_axis_in
-      integer,                           intent(in)    :: accum_type_in
-      real(REAL64),                      intent(in)    :: fill_val_in
-      integer,                           intent(in)    :: shape_in(:)
-      logical,                           intent(in)    :: flag_xyfill_in
-      integer,                 optional, intent(in)    :: block_sizes_in(:)
-      integer,                 optional, intent(in)    :: block_ind_in
-      type(hist_log_messages), optional, intent(inout) :: logger
-      call init_buffer(this, field_in, volume_in, horiz_axis_in, accum_type_in, &
-              fill_val_in, shape_in, flag_xyfill_in, block_sizes_in, &
-              block_ind_in, logger=logger)
-      call this%clear(logger=logger)
-      this%buff_type = 'buff_1dreal32'
-
-   end subroutine init_buff_1dreal32
-
-   !#######################################################################
-
-   subroutine buff_2dreal32_clear(this, logger)
-      use hist_msg_handler, only: hist_log_messages, hist_add_alloc_error
-
-      ! Dummy arguments
-      class(hist_buff_2dreal32_t),       intent(inout) :: this
-      type(hist_log_messages), optional, intent(inout) :: logger
-      ! Local variables
-      integer                     :: aerr
-      character(len=*), parameter :: subname = 'buff_2dreal32_clear'
-
-      if (.not. associated(this%data)) then
-         allocate(this%data(this%field_shape(1), this%field_shape(2)), stat=aerr)
-         if (aerr /= 0) then
-            call hist_add_alloc_error('data', __FILE__, __LINE__ - 2,         &
-                 subname=subname, errors=logger)
-         end if
-      end if
-      if (.not. associated(this%var_buffer) .and. this%accum_type == hist_accum_var) then
-         allocate(this%var_buffer(this%field_shape(1), this%field_shape(2)), stat=aerr)
-         if (aerr /= 0) then
-            call hist_add_alloc_error('var_buffer', __FILE__, __LINE__ - 2,         &
-                 subname=subname, errors=logger)
-         end if
-      end if
-      if (.not. allocated(this%num_samples)) then
-         allocate(this%num_samples(this%field_shape(1)), stat=aerr)
-         if (aerr /= 0) then
-            call hist_add_alloc_error('num_samples', __FILE__, __LINE__ - 2,         &
-                 subname=subname, errors=logger)
-         end if
-      end if
-      this%data = 0.0_REAL32
-      this%num_samples = 0
-      if (associated(this%var_buffer)) then
-         this%var_buffer = 0.0_REAL32
-      end if
-
-   end subroutine buff_2dreal32_clear
-
-   !#######################################################################
-
-   subroutine buff_2dreal32_value(this, norm_val, logger)
-      use hist_msg_handler, only: hist_log_messages
-
-      ! Dummy arguments
-      class(hist_buff_2dreal32_t),       intent(inout) :: this
-      real(REAL32),                      intent(inout) :: norm_val(:,:)
-      type(hist_log_messages), optional, intent(inout) :: logger
-      ! Local variable
-      integer :: ind1, ind2
-      integer :: nacc
-      real(REAL32) :: tmpfill, variance
-
-      if (this%accum_type /= hist_accum_var) then
-         do ind1 = 1, size(this%data,1)
-            nacc = this%num_samples(ind1)
-            do ind2 = 1, size(this%data,2)
-               if (nacc > 0) then
-                  norm_val(ind1, ind2) = this%data(ind1, ind2) / nacc
-               else if (this%flag_xyfill) then
-                  norm_val(ind1, ind2) = this%fill_value
-               end if
-            end do
-         end do
-      else
-         ! Standard deviation
-         ! from http://www.johndcook.com/blog/standard_deviation/
-         tmpfill = merge(real(this%fill_value, REAL32), 0.0_REAL32, this%flag_xyfill)
-         do ind1 = 1, size(this%data,1)
-            do ind2 = 1, size(this%data,2)
-               if (this%num_samples(ind1) > 0) then
-                  variance = this%var_buffer(ind1, ind2) / this%num_samples(ind1)
-                  norm_val(ind1, ind2) = sqrt(variance)
-               else
-                  norm_val(ind1, ind2) = tmpfill
-               end if
-            end do
-         end do
-      end if
-
-   end subroutine buff_2dreal32_value
-
-   !#######################################################################
-
-   subroutine buff_2dreal32_accum(this, field, cols_or_block, cole, logger)
-      use hist_msg_handler, only: hist_log_messages
-      ! Dummy arguments
-      class(hist_buff_2dreal32_t),       intent(inout) :: this
-      real(REAL32),                      intent(in)    :: field(:,:)
-      integer,                           intent(in)    :: cols_or_block
-      integer,                 optional, intent(in)    :: cole
-      type(hist_log_messages), optional, intent(inout) :: logger
-      ! Local variables
-      integer      :: col_beg_use
-      integer      :: col_end_use
-      integer      :: ind1, ind2
-      real(REAL32) :: fld_val, tmp
-
-      if (this%has_blocks()) then
-         ! For a blocked field, <cols_or_block> is a block index
-         col_beg_use = this%block_begs(cols_or_block)
-         col_end_use = this%block_ends(cols_or_block)
-      else
-         ! Non blocked, <cols_or_block> is the first column index
-         col_beg_use = cols_or_block
-         if (present(cole)) then
-            col_end_use = cole
-         else
-            col_end_use = col_beg_use +                                       &
-                 this%field_shape(this%horiz_axis_ind) - 1
-         end if
-      end if
-
-      select case (this%accum_type)
-      case (hist_accum_lst)
-         do ind1 = col_beg_use, col_end_use
-            this%num_samples(ind1) = 0
-            ! Only set samples to 1 if this column does not have fill values
-            if (this%flag_xyfill .and. field(ind1 - col_beg_use + 1, 1) /= this%fill_value) then
-               this%num_samples(ind1) = 1
-            end if
-            do ind2 = 1, size(field,2)
-               fld_val = field(ind1 - col_beg_use + 1, ind2)
-               this%data(ind1, ind2) = fld_val
-            end do
-         end do
-         if (this%flag_xyfill) then
-            ! Check if assumption that columns are consistent wrt fill value was accurate
-            call this%check_fill_value(field(col_beg_use:col_end_use, :), logger)
-         end if
-      case (hist_accum_min)
-         do ind1 = col_beg_use, col_end_use
-            do ind2 = 1, size(field, 2)
-               fld_val = field(ind1 - col_beg_use + 1, ind2)
-               if (this%flag_xyfill) then
-                  ! If the buffer (possibly) contains fill values,
-                  ! only check for or set minimum if not a fill value
-                  if (this%num_samples(ind1) == 0) then
-                     if (fld_val /= this%fill_value) then
-                        this%data(ind1, ind2) = fld_val
-                        this%num_samples(ind1) = 1
-                     else
-                        ! Set to large positive number if this is a fill value
-                        ! Also do not change num_samples - if num_samples
-                        ! is zero at the end of the accumulation period,
-                        ! the value will be overwritten to fill_value
-                        this%data(ind1, ind2) = HUGE(REAL32)
-                     end if
-                  else if (fld_val < this%data(ind1, ind2) .and. fld_val /= this%fill_value) then
-                     this%data(ind1, ind2) = fld_val
-                     this%num_samples(ind1) = 1
-                  end if ! No else, we already have the minimum value for this col
-               else
-                  if (this%num_samples(ind1) == 0 .or. fld_val < this%data(ind1, ind2)) then
-                     this%data(ind1, ind2) = fld_val
-                     this%num_samples(ind1) = 1
-                  end if ! No else, we already have the minimum value for this col
-               end if
-            end do
-         end do
-         if (this%flag_xyfill) then
-            call this%check_fill_value(field(col_beg_use:col_end_use, :), logger)
-         end if
-      case (hist_accum_max)
-         do ind1 = col_beg_use, col_end_use
-            do ind2 = 1, size(field, 2)
-               fld_val = field(ind1 - col_beg_use + 1, ind2)
-               if (this%flag_xyfill) then
-                  ! If the buffer (possibly) contains fill values,
-                  ! only check for maximum if not a fill value
-                  if (this%num_samples(ind1) == 0) then
-                     if (fld_val /= this%fill_value) then
-                        this%data(ind1, ind2) = fld_val
-                        this%num_samples(ind1) = 1
-                     else
-                        ! Set to large negative number if this is a fill value
-                        ! Also do not change num_samples - if num_samples
-                        ! is zero at the end of the accumulation period,
-                        ! the value will be overwritten to fill_value
-                        this%data(ind1, ind2) = -HUGE(REAL32)
-                     end if
-                  else if (fld_val > this%data(ind1, ind2) .and. fld_val /= this%fill_value) then
-                     this%data(ind1, ind2) = fld_val
-                     this%num_samples(ind1) = 1
-                  end if ! No else, we already have the maximum value for this col
-               else
-                  if (this%num_samples(ind1) == 0 .or. fld_val > this%data(ind1, ind2)) then
-                     this%data(ind1, ind2) = fld_val
-                     this%num_samples(ind1) = 1
-                  end if ! No else, we already have the maximum value for this col
-               end if
-            end do
-         end do
-         if (this%flag_xyfill) then
-            call this%check_fill_value(field(col_beg_use:col_end_use, :), logger)
-         end if
-      case (hist_accum_avg)
-         do ind1 = col_beg_use, col_end_use
-            do ind2 = 1, size(field, 2)
-               fld_val = field(ind1 - col_beg_use + 1, ind2)
-               ! Compute running sum
-               if (this%flag_xyfill) then
-                  ! Only include sample if it's not a fill value
-                  if (fld_val /= this%fill_value) then
-                     this%data(ind1, ind2) = this%data(ind1, ind2) + fld_val
-                     this%num_samples(ind1) = this%num_samples(ind1) + 1
-                  end if
-               else
-                  this%data(ind1, ind2) = this%data(ind1, ind2) + fld_val
-                  this%num_samples(ind1) = this%num_samples(ind1) + 1
-               end if
-            end do
-         end do
-         if (this%flag_xyfill) then
-            call this%check_fill_value(field(col_beg_use:col_end_use, :), logger)
-         end if
-      case (hist_accum_var)
-         do ind1 = col_beg_use, col_end_use
-            do ind2 = 1, size(field,2)
-               fld_val = field(ind1 - col_beg_use + 1, ind2)
-               if (this%flag_xyfill) then
-                  if (fld_val /= this%fill_value) then
-                     ! Only include the sample if it's not a fill value
-                     if (this%num_samples(ind1) == 0) then
-                        this%data(ind1, ind2) = fld_val
-                        this%var_buffer(ind1, ind2) = 0._REAL32
-                        this%num_samples(ind1) = this%num_samples(ind1) + 1
-                     else
-                        tmp = this%data(ind1, ind2)
-                        this%num_samples(ind1) = this%num_samples(ind1) + 1
-                        this%data(ind1, ind2) = this%data(ind1, ind2) + &
-                                (fld_val - this%data(ind1, ind2)) / &
-                                this%num_samples(ind1)
-                        this%var_buffer(ind1, ind2) = this%var_buffer(ind1, ind2) + &
-                                (fld_val - this%data(ind1, ind2)) * &
-                                (fld_val - tmp)
-                     end if
-                  end if
-               else
-                  if (this%num_samples(ind1) == 0) then
-                     this%data(ind1, ind2) = fld_val
-                     this%var_buffer(ind1, ind2) = 0._REAL32
-                     this%num_samples(ind1) = this%num_samples(ind1) + 1
-                  else
-                     tmp = this%data(ind1, ind2)
-                     this%num_samples(ind1) = this%num_samples(ind1) + 1
-                     this%data(ind1, ind2) = this%data(ind1, ind2) + &
-                             (fld_val - this%data(ind1, ind2)) / &
-                             this%num_samples(ind1)
-                     this%var_buffer(ind1, ind2) = this%var_buffer(ind1, ind2) + &
-                             (fld_val - this%data(ind1, ind2)) * &
-                             (fld_val - tmp)
-                  end if
-               end if
-            end do
-         end do
-         if (this%flag_xyfill) then
-            call this%check_fill_value(field(col_beg_use:col_end_use, :), logger)
-         end if
-      end select
-
-   end subroutine buff_2dreal32_accum
-
-   !#######################################################################
-
-   subroutine buff_2dreal32_check_fill(this, field, logger)
-      use hist_msg_handler, only: hist_log_messages, hist_add_error, ERROR
-      ! Ensure that columns have fillvalue applied consistently across levels
-      class(hist_buff_2dreal32_t),       intent(inout) :: this
-      real(REAL32),                      intent(in)    :: field(:,:)
-      type(hist_log_messages), optional, intent(inout) :: logger
-      ! Local variables
-      character(len=512) :: errstr
-      integer :: idx, jdx
-
-      do jdx = 2, size(field, 2)
-         do idx = 1, size(field, 1)
-            if (field(idx,1) == real(this%fill_value, REAL32) .and. &
-                 field(idx,jdx) /= real(this%fill_value, REAL32) .or. &
-                 field(idx,1) /= real(this%fill_value, REAL32) .and. &
-                 field(idx,jdx) == real(this%fill_value, REAL32)) then
-               write(errstr, '(a,i0)') 'ERROR: fill value applied inconsistently for column ', idx
-               call hist_add_error('buff_2dreal32_check_fill', errstr, errors=logger)
-            end if
-         end do
-      end do
-   end subroutine buff_2dreal32_check_fill
-
-   !#######################################################################
-
-   subroutine buff_1dreal32_accum(this, field, cols_or_block, cole, logger)
-      use hist_msg_handler, only: hist_log_messages
-      ! Dummy arguments
-      class(hist_buff_1dreal32_t),       intent(inout) :: this
-      real(REAL32),                      intent(in)    :: field(:)
-      integer,                           intent(in)    :: cols_or_block
-      integer,                 optional, intent(in)    :: cole
-      type(hist_log_messages), optional, intent(inout) :: logger
-      ! Local variables
-      integer      :: col_beg_use
-      integer      :: col_end_use
-      integer      :: ind1
-      real(REAL32) :: fld_val, tmp
-
-      if (this%has_blocks()) then
-         ! For a blocked field, <cols_or_block> is a block index
-         col_beg_use = this%block_begs(cols_or_block)
-         col_end_use = this%block_ends(cols_or_block)
-      else
-         ! Non blocked, <cols_or_block> is the first column index
-         col_beg_use = cols_or_block
-         if (present(cole)) then
-            col_end_use = cole
-         else
-            col_end_use = col_beg_use +                                       &
-                 this%field_shape(this%horiz_axis_ind) - 1
-         end if
-      end if
-
-      select case (this%accum_type)
-      case (hist_accum_lst)
-         do ind1 = col_beg_use, col_end_use
-            fld_val = field(ind1 - col_beg_use + 1)
-            if (this%flag_xyfill .and. fld_val == real(this%fill_value, REAL32)) then
-               ! Set num samples to 0 if this is a fill value
-               ! This will trigger logic in _value routine
-               this%data(ind1) = real(this%fill_value, REAL32)
-               this%num_samples(ind1) = 0
-            else
-               this%data(ind1) = fld_val
-               this%num_samples(ind1) = 1
-            end if
-         end do
-      case (hist_accum_min)
-         do ind1 = col_beg_use, col_end_use
-            fld_val = field(ind1 - col_beg_use + 1)
-            if (this%flag_xyfill) then
-               ! If the buffer (possibly) contains fill values,
-               ! only check for minimum if not a fill value
-               if (this%num_samples(ind1) == 0) then
-                  if (fld_val /= real(this%fill_value, REAL32)) then
-                     this%data(ind1) = fld_val
-                     this%num_samples(ind1) = 1
-                  else
-                     ! Set to large positive number if this is a fill value
-                     ! Also do not change num_samples - if num_samples
-                     ! is zero at the end of the accumulation period,
-                     ! the value will be overwritten to fill_value
-                     this%data(ind1) = HUGE(REAL32)
-                  end if
-               else if (fld_val < this%data(ind1) .and. fld_val /= real(this%fill_value, REAL32)) then
-                  this%data(ind1) = fld_val
-                  this%num_samples(ind1) = 1
-               end if ! No else, we already have the minimum value for this col
-            else
-               if (this%num_samples(ind1) == 0 .or. fld_val < this%data(ind1)) then
-                  this%data(ind1) = fld_val
-                  this%num_samples(ind1) = 1
-               end if ! No else, we already have the minimum value for this col
-            end if
-         end do
-      case (hist_accum_max)
-         do ind1 = col_beg_use, col_end_use
-            fld_val = field(ind1 - col_beg_use + 1)
-            if (this%flag_xyfill) then
-               ! If the buffer (possibly) contains fill values,
-               ! only check for maximum if not a fill value
-               if (this%num_samples(ind1) == 0) then
-                  if (fld_val /= real(this%fill_value, REAL32)) then
-                     this%data(ind1) = fld_val
-                     this%num_samples(ind1) = 1
-                  else
-                     ! Set to large negative number if this is a fill value
-                     ! Also do not change num_samples - if num_samples
-                     ! is zero at the end of the accumulation period,
-                     ! the value will be overwritten to fill_value
-                     this%data(ind1) = -HUGE(REAL32)
-                  end if
-               else if (fld_val > this%data(ind1) .and. fld_val /= real(this%fill_value, REAL32)) then
-                  this%data(ind1) = fld_val
-                  this%num_samples(ind1) = 1
-               end if ! No else, we already have the maximum value for this col
-            else
-               if (this%num_samples(ind1) == 0 .or. fld_val > this%data(ind1)) then
-                  this%data(ind1) = fld_val
-                  this%num_samples(ind1) = 1
-               end if ! No else, we already have the maximum value for this col
-            end if
-         end do
-      case (hist_accum_avg)
-         do ind1 = col_beg_use, col_end_use
-            fld_val = field(ind1 - col_beg_use + 1)
-            if (this%flag_xyfill) then
-               ! Only include samples that aren't fill values
-               if (this%data(ind1) /= real(this%fill_value, REAL32)) then
-                  this%data(ind1) = this%data(ind1) + fld_val
-                  this%num_samples(ind1) = this%num_samples(ind1) + 1
-               end if
-            else
-               this%data(ind1) = this%data(ind1) + fld_val
-               this%num_samples(ind1) = this%num_samples(ind1) + 1
-            end if
-         end do
-      case (hist_accum_var)
-         do ind1 = col_beg_use, col_end_use
-            fld_val = field(ind1 - col_beg_use + 1)
-            if (this%flag_xyfill) then
-               if (fld_val /= real(this%fill_value, REAL32)) then
-                  ! Only include the sample if it's not a fill value
-                  if (this%num_samples(ind1) == 0) then
-                     this%data(ind1) = fld_val
-                     this%var_buffer(ind1) = 0._REAL32
-                     this%num_samples(ind1) = this%num_samples(ind1) + 1
-                  else
-                     tmp = this%data(ind1)
-                     this%num_samples(ind1) = this%num_samples(ind1) + 1
-                     this%data(ind1) = this%data(ind1) + &
-                             (fld_val - this%data(ind1)) / &
-                             this%num_samples(ind1)
-                     this%var_buffer(ind1) = this%var_buffer(ind1) + &
-                             (fld_val - this%data(ind1)) * &
-                             (fld_val - tmp)
-                  end if
-               end if
-            else
-               if (this%num_samples(ind1) == 0) then
-                  this%data(ind1) = fld_val
-                  this%var_buffer(ind1) = 0._REAL32
-                  this%num_samples(ind1) = this%num_samples(ind1) + 1
-               else
-                  tmp = this%data(ind1)
-                  this%num_samples(ind1) = this%num_samples(ind1) + 1
-                  this%data(ind1) = this%data(ind1) + &
-                          (fld_val - this%data(ind1)) / &
-                          this%num_samples(ind1)
-                  this%var_buffer(ind1) = this%var_buffer(ind1) + &
-                          (fld_val - this%data(ind1)) * &
-                          (fld_val - tmp)
-               end if
-            end if
-         end do
-      end select
-
-   end subroutine buff_1dreal32_accum
-
-   !#######################################################################
-
-   subroutine buff_1dreal32_value(this, norm_val, logger)
-      use hist_msg_handler, only: hist_log_messages
-
-      ! Dummy arguments
-      class(hist_buff_1dreal32_t),       intent(inout) :: this
-      real(REAL32),                      intent(inout) :: norm_val(:)
-      type(hist_log_messages), optional, intent(inout) :: logger
-      ! Local variable
-      integer :: ind1
-      integer :: nacc
-      real(REAL32) :: tmpfill, variance
-
-      if (this%accum_type /= hist_accum_var) then
-         do ind1 = 1, size(this%data,1)
-            nacc = this%num_samples(ind1)
-            if (nacc > 0) then
-               norm_val(ind1) = this%data(ind1) / nacc
-            else if (this%flag_xyfill) then
-               norm_val(ind1) = this%fill_value
-            end if
-         end do
-      else
-         ! Standard deviation
-         ! from http://www.johndcook.com/blog/standard_deviation/
-         tmpfill = merge(real(this%fill_value, REAL32), 0.0_REAL32, this%flag_xyfill)
-         do ind1 = 1, size(this%data,1)
-            if (this%num_samples(ind1) > 0) then
-               variance = this%var_buffer(ind1) / this%num_samples(ind1)
-               norm_val(ind1) = sqrt(variance)
-            else
-               norm_val(ind1) = tmpfill
-            end if
-         end do
-      end if
-
-
-   end subroutine buff_1dreal32_value
-
-   !#######################################################################
-
-   subroutine buff_1dreal64_clear(this, logger)
-      use hist_msg_handler, only: hist_log_messages, hist_add_alloc_error
-
-      ! Dummy arguments
-      class(hist_buff_1dreal64_t),       intent(inout) :: this
-      type(hist_log_messages), optional, intent(inout) :: logger
-      ! Local variables
-      integer                     :: aerr
-      character(len=*), parameter :: subname = 'buff_1dreal64_clear'
+      character(len=*), parameter :: subname = 'buff_1d_clear'
 
       if (.not. associated(this%data)) then
          allocate(this%data(this%field_shape(1)), stat=aerr)
@@ -881,16 +303,16 @@ CONTAINS
          this%var_buffer = 0.0_REAL64
       end if
 
-   end subroutine buff_1dreal64_clear
+   end subroutine buff_1d_clear
 
    !#######################################################################
 
-   subroutine init_buff_1dreal64(this, field_in, volume_in, horiz_axis_in, &
+   subroutine init_buff_1d(this, field_in, volume_in, horiz_axis_in, &
         accum_type_in, fill_val_in, shape_in, flag_xyfill_in, block_sizes_in, &
         block_ind_in, logger)
       use hist_msg_handler, only: hist_log_messages
 
-      class(hist_buff_1dreal64_t),       intent(inout) :: this
+      class(hist_buff_1d_t),       intent(inout) :: this
       class(hist_hashable_t),  pointer                 :: field_in
       integer,                           intent(in)    :: volume_in
       integer,                           intent(in)    :: horiz_axis_in
@@ -906,16 +328,16 @@ CONTAINS
               fill_val_in, shape_in, flag_xyfill_in, block_sizes_in,&
               block_ind_in, logger=logger)
       call this%clear(logger=logger)
-      this%buff_type = 'buff_1dreal64'
+      this%buff_type = 'buff_1d'
 
-   end subroutine init_buff_1dreal64
+   end subroutine init_buff_1d
 
    !#######################################################################
 
-   subroutine buff_1dreal64_accum(this, field, cols_or_block, cole, logger)
+   subroutine buff_1d_accum(this, field, cols_or_block, cole, logger)
       use hist_msg_handler, only: hist_log_messages
       ! Dummy arguments
-      class(hist_buff_1dreal64_t),       intent(inout) :: this
+      class(hist_buff_1d_t),       intent(inout) :: this
       real(REAL64),                      intent(in)    :: field(:)
       integer,                           intent(in)    :: cols_or_block
       integer,                 optional, intent(in)    :: cole
@@ -1069,14 +491,14 @@ CONTAINS
          end do
       end select
 
-   end subroutine buff_1dreal64_accum
+   end subroutine buff_1d_accum
 
    !#######################################################################
 
-   subroutine buff_1dreal64_value(this, norm_val, logger)
+   subroutine buff_1d_value(this, norm_val, logger)
       use hist_msg_handler, only: hist_log_messages, ERROR, VERBOSE
       ! Dummy arguments
-      class(hist_buff_1dreal64_t),       intent(inout) :: this
+      class(hist_buff_1d_t),       intent(inout) :: this
       real(REAL64),                      intent(inout) :: norm_val(:)
       type(hist_log_messages), optional, intent(inout) :: logger
       ! Local variable
@@ -1107,19 +529,19 @@ CONTAINS
          end do
       end if
 
-   end subroutine buff_1dreal64_value
+   end subroutine buff_1d_value
 
    !#######################################################################
 
-   subroutine buff_2dreal64_clear(this, logger)
+   subroutine buff_2d_clear(this, logger)
       use hist_msg_handler, only: hist_log_messages, hist_add_alloc_error
 
       ! Dummy arguments
-      class(hist_buff_2dreal64_t),       intent(inout) :: this
+      class(hist_buff_2d_t),       intent(inout) :: this
       type(hist_log_messages), optional, intent(inout) :: logger
       ! Local variables
       integer                     :: aerr
-      character(len=*), parameter :: subname = 'buff_2dreal64_clear'
+      character(len=*), parameter :: subname = 'buff_2d_clear'
 
       if (.not. associated(this%data)) then
          allocate(this%data(this%field_shape(1), this%field_shape(2)), stat=aerr)
@@ -1148,16 +570,16 @@ CONTAINS
          this%var_buffer = 0.0_REAL64
       end if
 
-   end subroutine buff_2dreal64_clear
+   end subroutine buff_2d_clear
 
    !#######################################################################
 
-   subroutine init_buff_2dreal64(this, field_in, volume_in, horiz_axis_in, &
+   subroutine init_buff_2d(this, field_in, volume_in, horiz_axis_in, &
         accum_type_in, fill_val_in, shape_in, flag_xyfill_in, block_sizes_in, &
         block_ind_in, logger)
       use hist_msg_handler, only: hist_log_messages
 
-      class(hist_buff_2dreal64_t),       intent(inout) :: this
+      class(hist_buff_2d_t),       intent(inout) :: this
       class(hist_hashable_t),  pointer                 :: field_in
       integer,                           intent(in)    :: volume_in
       integer,                           intent(in)    :: horiz_axis_in
@@ -1173,16 +595,16 @@ CONTAINS
               fill_val_in, shape_in, flag_xyfill_in, block_sizes_in, &
               block_ind_in, logger=logger)
       call this%clear(logger=logger)
-      this%buff_type = 'buff_2dreal64'
+      this%buff_type = 'buff_2d'
 
-   end subroutine init_buff_2dreal64
+   end subroutine init_buff_2d
 
    !#######################################################################
 
-   subroutine buff_2dreal64_accum(this, field, cols_or_block, cole, logger)
+   subroutine buff_2d_accum(this, field, cols_or_block, cole, logger)
       use hist_msg_handler, only: hist_log_messages
       ! Dummy arguments
-      class(hist_buff_2dreal64_t),       intent(inout) :: this
+      class(hist_buff_2d_t),       intent(inout) :: this
       real(REAL64),                      intent(in)    :: field(:,:)
       integer,                           intent(in)    :: cols_or_block
       integer,                 optional, intent(in)    :: cole
@@ -1317,18 +739,21 @@ CONTAINS
          end if
       case (hist_accum_var)
          do ind1 = col_beg_use, col_end_use
+            if (this%flag_xyfill .and. field(ind1 - col_beg_use + 1, 1) == this%fill_value) then
+               this%num_samples(ind1) = this%num_samples(ind1)
+            else
+               this%num_samples(ind1) = this%num_samples(ind1) + 1
+            end if
             do ind2 = 1, size(field,2)
                fld_val = field(ind1 - col_beg_use + 1, ind2)
                if (this%flag_xyfill) then
                   if (fld_val /= real(this%fill_value, REAL64)) then
                      ! Only include the sample if it's not a fill value
-                     if (this%num_samples(ind1) == 0) then
+                     if (this%num_samples(ind1) == 1) then
                         this%data(ind1, ind2) = fld_val
                         this%var_buffer(ind1, ind2) = 0._REAL64
-                        this%num_samples(ind1) = this%num_samples(ind1) + 1
                      else
                         tmp = this%data(ind1, ind2)
-                        this%num_samples(ind1) = this%num_samples(ind1) + 1
                         this%data(ind1, ind2) = this%data(ind1, ind2) + &
                                 (fld_val - this%data(ind1, ind2)) / &
                                 this%num_samples(ind1)
@@ -1338,13 +763,11 @@ CONTAINS
                      end if
                   end if
                else
-                  if (this%num_samples(ind1) == 0) then
+                  if (this%num_samples(ind1) == 1) then
                      this%data(ind1, ind2) = fld_val
                      this%var_buffer(ind1, ind2) = 0._REAL64
-                     this%num_samples(ind1) = this%num_samples(ind1) + 1
                   else
                      tmp = this%data(ind1, ind2)
-                     this%num_samples(ind1) = this%num_samples(ind1) + 1
                      this%data(ind1, ind2) = this%data(ind1, ind2) + &
                              (fld_val - this%data(ind1, ind2)) / &
                              this%num_samples(ind1)
@@ -1360,14 +783,14 @@ CONTAINS
          end if
       end select
 
-   end subroutine buff_2dreal64_accum
+   end subroutine buff_2d_accum
 
    !#######################################################################
 
-   subroutine buff_2dreal64_check_fill(this, field, logger)
+   subroutine buff_2d_check_fill(this, field, logger)
       use hist_msg_handler, only: hist_log_messages, hist_add_error, ERROR
       ! Ensure that columns have fill value applied consistently across levels
-      class(hist_buff_2dreal64_t),       intent(inout) :: this
+      class(hist_buff_2d_t),       intent(inout) :: this
       real(REAL64),                      intent(in)    :: field(:,:)
       type(hist_log_messages), optional, intent(inout) :: logger
       ! Local variables
@@ -1379,18 +802,18 @@ CONTAINS
             if (field(idx,1) == this%fill_value .and. field(idx,jdx) /= this%fill_value .or. &
                  field(idx,1) /= this%fill_value .and. field(idx,jdx) == this%fill_value) then
                write(errstr, '(a,i0)') 'ERROR: fill value applied inconsistently for column ', idx
-               call hist_add_error('buff_2dreal64_check_fill', errstr, errors=logger)
+               call hist_add_error('buff_2d_check_fill', errstr, errors=logger)
             end if
          end do
       end do
-   end subroutine buff_2dreal64_check_fill
+   end subroutine buff_2d_check_fill
 
    !#######################################################################
 
-   subroutine buff_2dreal64_value(this, norm_val, logger)
+   subroutine buff_2d_value(this, norm_val, logger)
       use hist_msg_handler, only: hist_log_messages, ERROR, VERBOSE
       ! Dummy arguments
-      class(hist_buff_2dreal64_t),       intent(inout) :: this
+      class(hist_buff_2d_t),       intent(inout) :: this
       real(REAL64),                      intent(inout) :: norm_val(:,:)
       type(hist_log_messages), optional, intent(inout) :: logger
       ! Local variable
@@ -1425,34 +848,7 @@ CONTAINS
          end do
       end if
 
-   end subroutine buff_2dreal64_value
-
-   !#######################################################################
-
-   subroutine init_buff_2dreal32(this, field_in, volume_in, horiz_axis_in, &
-        accum_type_in, fill_val_in, shape_in, flag_xyfill_in, block_sizes_in, &
-        block_ind_in, logger)
-      use hist_msg_handler, only: hist_log_messages
-
-      class(hist_buff_2dreal32_t),       intent(inout) :: this
-      class(hist_hashable_t),  pointer                 :: field_in
-      integer,                           intent(in)    :: volume_in
-      integer,                           intent(in)    :: horiz_axis_in
-      integer,                           intent(in)    :: accum_type_in
-      real(REAL64),                      intent(in)    :: fill_val_in
-      integer,                           intent(in)    :: shape_in(:)
-      logical,                           intent(in)    :: flag_xyfill_in
-      integer,                 optional, intent(in)    :: block_sizes_in(:)
-      integer,                 optional, intent(in)    :: block_ind_in
-      type(hist_log_messages), optional, intent(inout) :: logger
-
-      call init_buffer(this, field_in, volume_in, horiz_axis_in, accum_type_in, &
-              fill_val_in, shape_in, flag_xyfill_in, block_sizes_in, &
-              block_ind_in, logger=logger)
-      call this%clear(logger=logger)
-      this%buff_type = 'buff_2dreal32'
-
-   end subroutine init_buff_2dreal32
+   end subroutine buff_2d_value
 
    !#######################################################################
 
@@ -1482,33 +878,21 @@ CONTAINS
       character(len=*),                parameter :: subname = 'buffer_factory'
       ! For buffer                     allocation
       integer                                    :: aerr
-      type(hist_buff_1dreal32_t), pointer :: real32_1 => NULL()
-      type(hist_buff_2dreal32_t), pointer :: real32_2 => NULL()
-      type(hist_buff_1dreal64_t), pointer :: real64_1 => NULL()
-      type(hist_buff_2dreal64_t), pointer :: real64_2 => NULL()
+      type(hist_buff_1d_t), pointer :: real_1 => NULL()
+      type(hist_buff_2d_t), pointer :: real_2 => NULL()
 
       nullify(newbuf)
       ! Create new buffer
       select case (trim(buffer_type))
-      case ('real32_1')
-         allocate(real32_1, stat=aerr)
+      case ('real_1')
+         allocate(real_1, stat=aerr)
          if (aerr == 0) then
-            newbuf => real32_1
+            newbuf => real_1
          end if
-      case ('real32_2')
-         allocate(real32_2, stat=aerr)
+      case ('real_2')
+         allocate(real_2, stat=aerr)
          if (aerr == 0) then
-            newbuf => real32_2
-         end if
-      case ('real64_1')
-         allocate(real64_1, stat=aerr)
-         if (aerr == 0) then
-            newbuf => real64_1
-         end if
-      case ('real64_2')
-         allocate(real64_2, stat=aerr)
-         if (aerr == 0) then
-            newbuf => real64_2
+            newbuf => real_2
          end if
       case default
          call hist_add_error(subname,                                         &

--- a/src/hist_buffer.F90
+++ b/src/hist_buffer.F90
@@ -473,26 +473,27 @@ CONTAINS
       select case (this%accum_type)
       case (hist_accum_lst)
          do ind1 = col_beg_use, col_end_use
+            this%num_samples(ind1) = 0
+            ! Only set samples to 1 if this column does not have fill values
+            if (this%flag_xyfill .and. field(ind1 - col_beg_use + 1, 1) /= this%fill_value) then
+               this%num_samples(ind1) = 1
+            end if
             do ind2 = 1, size(field,2)
                fld_val = field(ind1 - col_beg_use + 1, ind2)
-               if (this%flag_xyfill .and. fld_val == this%fill_value) then
-                  ! Set num samples to 0 if this is a fill value
-                  ! This will trigger logic in _value routine
-                  this%data(ind1, ind2) = this%fill_value
-                  this%num_samples(ind1) = 0
-               else
-                  this%data(ind1, ind2) = fld_val
-                  this%num_samples(ind1) = 1
-               end if
+               this%data(ind1, ind2) = fld_val
             end do
          end do
+         if (this%flag_xyfill) then
+            ! Check if assumption that columns are consistent wrt fill value was accurate
+            call this%check_fill_value(field(col_beg_use:col_end_use, :), logger)
+         end if
       case (hist_accum_min)
          do ind1 = col_beg_use, col_end_use
             do ind2 = 1, size(field, 2)
                fld_val = field(ind1 - col_beg_use + 1, ind2)
                if (this%flag_xyfill) then
                   ! If the buffer (possibly) contains fill values,
-                  ! only check for minimum if not a fill value
+                  ! only check for or set minimum if not a fill value
                   if (this%num_samples(ind1) == 0) then
                      if (fld_val /= this%fill_value) then
                         this%data(ind1, ind2) = fld_val
@@ -559,7 +560,7 @@ CONTAINS
                ! Compute running sum
                if (this%flag_xyfill) then
                   ! Only include sample if it's not a fill value
-                  if (fld_val /= real(this%fill_value, REAL32)) then
+                  if (fld_val /= this%fill_value) then
                      this%data(ind1, ind2) = this%data(ind1, ind2) + fld_val
                      this%num_samples(ind1) = this%num_samples(ind1) + 1
                   end if
@@ -577,7 +578,7 @@ CONTAINS
             do ind2 = 1, size(field,2)
                fld_val = field(ind1 - col_beg_use + 1, ind2)
                if (this%flag_xyfill) then
-                  if (fld_val /= real(this%fill_value, REAL32)) then
+                  if (fld_val /= this%fill_value) then
                      ! Only include the sample if it's not a fill value
                      if (this%num_samples(ind1) == 0) then
                         this%data(ind1, ind2) = fld_val
@@ -683,7 +684,7 @@ CONTAINS
                ! Set num samples to 0 if this is a fill value
                ! This will trigger logic in _value routine
                this%data(ind1) = real(this%fill_value, REAL32)
-               this%num_samples = 0
+               this%num_samples(ind1) = 0
             else
                this%data(ind1) = fld_val
                this%num_samples(ind1) = 1
@@ -1210,19 +1211,24 @@ CONTAINS
       select case (this%accum_type)
       case (hist_accum_lst)
          do ind1 = col_beg_use, col_end_use
+            this%num_samples(ind1) = 0
+            ! Only set samples for this column if not a fill value
+            if (this%flag_xyfill .and. field(ind1 - col_beg_use + 1, 1) /= this%fill_value) then
+               this%num_samples(ind1) = 1
+            end if
             do ind2 = 1, size(field,2)
                fld_val = field(ind1 - col_beg_use + 1, ind2)
                if (this%flag_xyfill .and. fld_val == this%fill_value) then
-                  ! Set num samples to 0 if this is a fill value
-                  ! This will trigger logic in _value routine
                   this%data(ind1, ind2) = this%fill_value
-                  this%num_samples(ind1) = 0
                else
                   this%data(ind1, ind2) = fld_val
-                  this%num_samples(ind1) = 1
                end if
             end do
          end do
+         if (this%flag_xyfill) then
+            ! Check if assumption that columns are consistent wrt fill value was accurate
+            call this%check_fill_value(field(col_beg_use:col_end_use, :), logger)
+         end if
       case (hist_accum_min)
          do ind1 = col_beg_use, col_end_use
             do ind2 = 1, size(field, 2)

--- a/src/hist_buffer.F90
+++ b/src/hist_buffer.F90
@@ -1,5 +1,5 @@
 module hist_buffer
-   use ISO_FORTRAN_ENV, only: REAL64, INT32, INT64
+   use ISO_FORTRAN_ENV, only: REAL64
    use hist_hashable,   only: hist_hashable_t
 
    implicit none
@@ -7,7 +7,7 @@ module hist_buffer
 
    ! Public interfaces
    public :: buffer_factory
-   
+
    ! Accumulation types -- the integers and array positions below must match
    integer, parameter, public :: hist_accum_lst = 1 ! last sample
    integer, parameter, public :: hist_accum_min = 2 ! minimum sample
@@ -53,8 +53,8 @@ module hist_buffer
    end type hist_buffer_t
 
    type, public, extends(hist_buffer_t) :: hist_buff_1d_t
-      real(REAL64), pointer :: data(:) => NULL()
-      real(REAL64), pointer :: var_buffer(:) => NULL()
+      real(REAL64), allocatable :: data(:)
+      real(REAL64), allocatable :: var_buffer(:)
       integer,  allocatable,   private :: num_samples(:)
    CONTAINS
       procedure :: clear => buff_1d_clear
@@ -64,8 +64,8 @@ module hist_buffer
    end type hist_buff_1d_t
 
    type, public, extends(hist_buffer_t) :: hist_buff_2d_t
-      real(REAL64), pointer :: data(:,:) => NULL()
-      real(REAL64), pointer :: var_buffer(:,:) => NULL()
+      real(REAL64), allocatable :: data(:,:)
+      real(REAL64), allocatable :: var_buffer(:,:)
       integer, allocatable,    private :: num_samples(:)
    CONTAINS
       procedure :: clear => buff_2d_clear
@@ -266,14 +266,14 @@ CONTAINS
       integer                     :: aerr
       character(len=*), parameter :: subname = 'buff_1d_clear'
 
-      if (.not. associated(this%data)) then
+      if (.not. allocated(this%data)) then
          allocate(this%data(this%field_shape(1)), stat=aerr)
          if (aerr /= 0) then
             call hist_add_alloc_error('data', __FILE__, __LINE__ - 1,         &
                  subname=subname, errors=logger)
          end if
       end if
-      if (.not. associated(this%var_buffer) .and. this%accum_type == hist_accum_var) then
+      if (.not. allocated(this%var_buffer) .and. this%accum_type == hist_accum_var) then
          allocate(this%var_buffer(this%field_shape(1)), stat=aerr)
          if (aerr /= 0) then
             call hist_add_alloc_error('var_buffer', __FILE__, __LINE__ - 2,         &
@@ -289,7 +289,7 @@ CONTAINS
       end if
       this%data = 0.0_REAL64
       this%num_samples = 0
-      if (associated(this%var_buffer)) then
+      if (allocated(this%var_buffer)) then
          this%var_buffer = 0.0_REAL64
       end if
 
@@ -301,7 +301,7 @@ CONTAINS
         accum_type_in, shape_in, block_sizes_in, block_ind_in, logger)
       use hist_msg_handler, only: hist_log_messages
 
-      class(hist_buff_1d_t),       intent(inout) :: this
+      class(hist_buff_1d_t),             intent(inout) :: this
       class(hist_hashable_t),  pointer                 :: field_in
       integer,                           intent(in)    :: volume_in
       integer,                           intent(in)    :: horiz_axis_in
@@ -441,6 +441,8 @@ CONTAINS
             end if
          end do
       case (hist_accum_var)
+         ! Standard deviation using Welford's algorithm
+         ! DOI: 10.1080/00401706.1962.10490022
          do ind1 = col_beg_use, col_end_use
             fld_val = field(ind1 - col_beg_use + 1)
             if (flag_xyfill) then
@@ -507,10 +509,10 @@ CONTAINS
             end if
          end do
       else
-         ! Standard deviation
-         ! from http://www.johndcook.com/blog/standard_deviation/
+         ! Standard deviation using Welford's algorithm
+         ! DOI: 10.1080/00401706.1962.10490022
          tmpfill = merge(fill_value, 0.0_REAL64, flag_xyfill)
-         do ind1 = 1, size(this%data,1)
+         do ind1 = 1, this%field_shape(1)
             if (this%num_samples(ind1) > 0) then
                variance = this%var_buffer(ind1) / this%num_samples(ind1)
                norm_val(ind1) = sqrt(variance)
@@ -534,14 +536,14 @@ CONTAINS
       integer                     :: aerr
       character(len=*), parameter :: subname = 'buff_2d_clear'
 
-      if (.not. associated(this%data)) then
+      if (.not. allocated(this%data)) then
          allocate(this%data(this%field_shape(1), this%field_shape(2)), stat=aerr)
          if (aerr /= 0) then
             call hist_add_alloc_error('data', __FILE__, __LINE__ - 1,         &
                  subname=subname, errors=logger)
          end if
       end if
-      if (.not. associated(this%var_buffer) .and. this%accum_type == hist_accum_var) then
+      if (.not. allocated(this%var_buffer) .and. this%accum_type == hist_accum_var) then
          allocate(this%var_buffer(this%field_shape(1), this%field_shape(2)), stat=aerr)
          if (aerr /= 0) then
             call hist_add_alloc_error('var_buffer', __FILE__, __LINE__ - 2,         &
@@ -557,7 +559,7 @@ CONTAINS
       end if
       this%data = 0.0_REAL64
       this%num_samples = 0
-      if (associated(this%var_buffer)) then
+      if (allocated(this%var_buffer)) then
          this%var_buffer = 0.0_REAL64
       end if
 
@@ -629,7 +631,7 @@ CONTAINS
             else
                this%num_samples(ind1) = 1
             end if
-            do ind2 = 1, size(field,2)
+            do ind2 = 1, this%field_shape(2)
                fld_val = field(ind1 - col_beg_use + 1, ind2)
                if (flag_xyfill .and. fld_val == fill_value) then
                   this%data(ind1, ind2) = fill_value
@@ -644,7 +646,7 @@ CONTAINS
          end if
       case (hist_accum_min)
          do ind1 = col_beg_use, col_end_use
-            do ind2 = 1, size(field, 2)
+            do ind2 = 1, this%field_shape(2)
                fld_val = field(ind1 - col_beg_use + 1, ind2)
                if (flag_xyfill) then
                   ! If the buffer (possibly) contains fill values,
@@ -677,7 +679,7 @@ CONTAINS
          end if
       case (hist_accum_max)
          do ind1 = col_beg_use, col_end_use
-            do ind2 = 1, size(field, 2)
+            do ind2 = 1, this%field_shape(2)
                fld_val = field(ind1 - col_beg_use + 1, ind2)
                if (flag_xyfill) then
                   ! If the buffer (possibly) contains fill values,
@@ -710,7 +712,7 @@ CONTAINS
          end if
       case (hist_accum_avg)
          do ind1 = col_beg_use, col_end_use
-            do ind2 = 1, size(field, 2)
+            do ind2 = 1, this%field_shape(2)
                fld_val = field(ind1 - col_beg_use + 1, ind2)
                ! Compute running sum
                if (flag_xyfill) then
@@ -729,13 +731,15 @@ CONTAINS
             call this%check_fill_value(field(col_beg_use:col_end_use, :), fill_value, logger)
          end if
       case (hist_accum_var)
+         ! Standard deviation using Welford's algorithm
+         ! DOI: 10.1080/00401706.1962.10490022
          do ind1 = col_beg_use, col_end_use
             if (flag_xyfill .and. field(ind1 - col_beg_use + 1, 1) == fill_value) then
                this%num_samples(ind1) = this%num_samples(ind1)
             else
                this%num_samples(ind1) = this%num_samples(ind1) + 1
             end if
-            do ind2 = 1, size(field,2)
+            do ind2 = 1, this%field_shape(2)
                fld_val = field(ind1 - col_beg_use + 1, ind2)
                if (flag_xyfill) then
                   if (fld_val /= fill_value) then
@@ -788,16 +792,24 @@ CONTAINS
       ! Local variables
       character(len=512) :: errstr
       integer :: idx, jdx
+      logical :: error_found
 
-      do jdx = 2, size(field, 2)
-         do idx = 1, size(field, 1)
+      error_found = .false.
+      do jdx = 2, this%field_shape(2)
+         do idx = 1, this%field_shape(1)
             if (field(idx,1) == fill_value .and. field(idx,jdx) /= fill_value .or. &
                  field(idx,1) /= fill_value .and. field(idx,jdx) == fill_value) then
                write(errstr, '(a,i0)') 'ERROR: fill value applied inconsistently for column ', idx
                call hist_add_error('buff_2d_check_fill', errstr, errors=logger)
+               error_found = .true.
+               exit
             end if
          end do
+         if (error_found) then
+            exit
+         end if
       end do
+
    end subroutine buff_2d_check_fill
 
    !#######################################################################
@@ -827,11 +839,11 @@ CONTAINS
             end do
          end do
       else
-         ! Standard deviation
-         ! from http://www.johndcook.com/blog/standard_deviation/
+         ! Standard deviation using Welford's algorithm
+         ! DOI: 10.1080/00401706.1962.10490022
          tmpfill = merge(fill_value, 0.0_REAL64, flag_xyfill)
-         do ind1 = 1, size(this%data,1)
-            do ind2 = 1, size(this%data,2)
+         do ind1 = 1, this%field_shape(1)
+            do ind2 = 1, this%field_shape(2)
                if (this%num_samples(ind1) > 0) then
                   variance = this%var_buffer(ind1, ind2) / this%num_samples(ind1)
                   norm_val(ind1, ind2) = sqrt(variance)
@@ -869,8 +881,9 @@ CONTAINS
       type(hist_log_messages), optional, intent(inout) :: logger
 
       ! Local variables
-      character(len=*),                parameter :: subname = 'buffer_factory'
-      ! For buffer                     allocation
+      character(len=*),   parameter :: subname = 'buffer_factory'
+      character(len=512)            :: alloc_errmsg
+      ! For buffer allocation
       integer                                    :: aerr
       type(hist_buff_1d_t), pointer :: real_1 => NULL()
       type(hist_buff_2d_t), pointer :: real_2 => NULL()
@@ -879,14 +892,22 @@ CONTAINS
       ! Create new buffer
       select case (trim(buffer_type))
       case ('real_1')
-         allocate(real_1, stat=aerr)
+         allocate(real_1, stat=aerr, errmsg=alloc_errmsg)
          if (aerr == 0) then
             newbuf => real_1
+         else
+            call hist_add_error(subname, &
+               "Failed to allocate real_1 buffer, errmsg = ", &
+               errstr2=trim(alloc_errmsg), errors=logger)
          end if
       case ('real_2')
-         allocate(real_2, stat=aerr)
+         allocate(real_2, stat=aerr, errmsg=alloc_errmsg)
          if (aerr == 0) then
             newbuf => real_2
+         else
+            call hist_add_error(subname, &
+               "Failed to allocate real_2 buffer, errmsg = ", &
+               errstr2=trim(alloc_errmsg), errors=logger)
          end if
       case default
          call hist_add_error(subname,                                         &

--- a/src/hist_buffer.F90
+++ b/src/hist_buffer.F90
@@ -623,9 +623,10 @@ CONTAINS
       select case (this%accum_type)
       case (hist_accum_lst)
          do ind1 = col_beg_use, col_end_use
-            this%num_samples(ind1) = 0
             ! Only set samples for this column if not a fill value
-            if (flag_xyfill .and. field(ind1 - col_beg_use + 1, 1) /= fill_value) then
+            if (flag_xyfill .and. field(ind1 - col_beg_use + 1, 1) == fill_value) then
+               this%num_samples(ind1) = 0
+            else
                this%num_samples(ind1) = 1
             end if
             do ind2 = 1, size(field,2)

--- a/src/hist_field.F90
+++ b/src/hist_field.F90
@@ -1,4 +1,5 @@
 module hist_field
+   use ISO_FORTRAN_ENV, only: REAL64
    ! Module containing DDTs for history fields and associated routines
 
    use hist_hashable, only: hist_hashable_t
@@ -27,6 +28,7 @@ module hist_field
       integer,                       private :: field_num_levels
       integer,          allocatable, private :: field_dimensions(:)
       logical,                       private :: field_flag_xyfill
+      real(REAL64),                  private :: fillvalue
       integer,          allocatable, private :: field_beg_dims(:)
       integer,          allocatable, private :: field_end_dims(:)
       
@@ -51,6 +53,7 @@ module hist_field
       procedure :: end_dims        => get_end_dims
       procedure :: sampling_sequence => get_sampling_sequence
       procedure :: flag_xyfill       => get_flag_xyfill
+      procedure :: fill_value        => get_fill_value
       procedure :: mixing_ratio      => get_mixing_ratio
       procedure :: cell_methods      => get_cell_methods
       procedure :: set_dimension_bounds
@@ -74,8 +77,8 @@ CONTAINS
 
    subroutine hist_field_initialize(field, diag_name_in, std_name_in,         &
         long_name_in, units_in, type_in, decomp_in, mdim_indices, acc_type, num_levels,  &
-        field_shape, sampling_seq, flag_xyfill, mixing_ratio, dim_bounds, mdim_sizes, &
-        beg_dims, end_dims, cell_methods, errmsg)
+        field_shape, fill_value, sampling_seq, flag_xyfill, mixing_ratio, dim_bounds, &
+        mdim_sizes, beg_dims, end_dims, cell_methods, errmsg)
 
       type(hist_field_info_t), pointer               :: field
       character(len=*),                  intent(in)  :: diag_name_in
@@ -88,6 +91,7 @@ CONTAINS
       character(len=*),                  intent(in)  :: acc_type
       integer,                           intent(in)  :: num_levels
       integer,                           intent(in)  :: field_shape(:)
+      real(REAL64),                      intent(in)  :: fill_value
       character(len=*),        optional, intent(in)  :: sampling_seq
       logical,                 optional, intent(in)  :: flag_xyfill
       character(len=*),        optional, intent(in)  :: mixing_ratio
@@ -109,6 +113,7 @@ CONTAINS
       field%field_decomp = decomp_in
       field%field_accumulate_type = acc_type
       field%field_num_levels = num_levels
+      field%fillvalue = fill_value
       allocate(field%field_dimensions(size(mdim_indices, 1)))
       field%field_dimensions = mdim_indices
       allocate(field%field_shape(size(field_shape, 1)))
@@ -309,6 +314,16 @@ CONTAINS
       flag_xyfill = this%field_flag_xyfill
 
    end function get_flag_xyfill
+
+   !#######################################################################
+
+   function get_fill_value(this) result(fill_value)
+      class(hist_field_info_t), intent(in) :: this
+      real(REAL64)                         :: fill_value
+
+      fill_value = this%fillvalue
+
+   end function get_fill_value
 
    !#######################################################################
 

--- a/src/hist_field.F90
+++ b/src/hist_field.F90
@@ -177,7 +177,7 @@ CONTAINS
 
    !#######################################################################
 
-   function get_diag_name(this) result(info)
+   pure function get_diag_name(this) result(info)
       class(hist_field_info_t), intent(in) :: this
       character(len=:), allocatable        :: info
 
@@ -186,7 +186,7 @@ CONTAINS
 
    !#######################################################################
 
-   function get_standard_name(this) result(info)
+   pure function get_standard_name(this) result(info)
       class(hist_field_info_t), intent(in) :: this
       character(len=:), allocatable        :: info
 
@@ -195,7 +195,7 @@ CONTAINS
 
    !#######################################################################
 
-   function get_long_name(this) result(info)
+   pure function get_long_name(this) result(info)
       class(hist_field_info_t), intent(in) :: this
       character(len=:), allocatable        :: info
 
@@ -204,7 +204,7 @@ CONTAINS
 
    !#######################################################################
 
-   function get_units(this) result(info)
+   pure function get_units(this) result(info)
       class(hist_field_info_t), intent(in) :: this
       character(len=:), allocatable        :: info
 
@@ -213,7 +213,7 @@ CONTAINS
 
    !#######################################################################
 
-   function get_type(this) result(info)
+   pure function get_type(this) result(info)
       class(hist_field_info_t), intent(in) :: this
       character(len=:), allocatable        :: info
 
@@ -222,7 +222,7 @@ CONTAINS
 
    !#######################################################################
 
-   function get_kind(this) result(info)
+   pure function get_kind(this) result(info)
       class(hist_field_info_t), intent(in) :: this
       character(len=:), allocatable        :: info
 
@@ -231,7 +231,7 @@ CONTAINS
 
    !#######################################################################
 
-   function get_accumulate_type(this) result(info)
+   pure function get_accumulate_type(this) result(info)
       class(hist_field_info_t), intent(in) :: this
       character(len=:), allocatable        :: info
 
@@ -240,7 +240,7 @@ CONTAINS
 
    !#######################################################################
 
-   function get_decomp(this) result(decomp)
+   pure function get_decomp(this) result(decomp)
       class(hist_field_info_t), intent(in) :: this
       integer                              :: decomp
 
@@ -249,7 +249,7 @@ CONTAINS
 
    !#######################################################################
 
-   function get_num_levels(this) result(num_levels)
+   pure function get_num_levels(this) result(num_levels)
       class(hist_field_info_t), intent(in) :: this
       integer                              :: num_levels
 
@@ -258,7 +258,7 @@ CONTAINS
 
    !#######################################################################
 
-   function get_dimensions(this) result(dimensions)
+   pure function get_dimensions(this) result(dimensions)
       class(hist_field_info_t), intent(in) :: this
       integer,   allocatable               :: dimensions(:)
       allocate(dimensions(size(this%field_dimensions)))
@@ -267,7 +267,7 @@ CONTAINS
 
    !#######################################################################
 
-   function get_beg_dims(this) result(beg_dim)
+   pure function get_beg_dims(this) result(beg_dim)
       class(hist_field_info_t), intent(in) :: this
       integer,   allocatable               :: beg_dim(:)
       if (allocated(this%field_beg_dims)) then
@@ -278,7 +278,7 @@ CONTAINS
 
    !#######################################################################
 
-   function get_end_dims(this) result(end_dim)
+   pure function get_end_dims(this) result(end_dim)
       class(hist_field_info_t), intent(in) :: this
       integer,   allocatable               :: end_dim(:)
       if (allocated(this%field_end_dims)) then
@@ -289,7 +289,7 @@ CONTAINS
 
    !#######################################################################
 
-   function get_shape(this) result(field_shape)
+   pure function get_shape(this) result(field_shape)
       class(hist_field_info_t), intent(in) :: this
       integer,   allocatable               :: field_shape(:)
       allocate(field_shape(size(this%field_shape)))
@@ -298,7 +298,7 @@ CONTAINS
 
    !#######################################################################
 
-   function get_sampling_sequence(this) result(info)
+   pure function get_sampling_sequence(this) result(info)
       class(hist_field_info_t), intent(in) :: this
       character(len=:), allocatable        :: info
 
@@ -307,7 +307,7 @@ CONTAINS
 
    !#######################################################################
 
-   function get_flag_xyfill(this) result(flag_xyfill)
+   pure function get_flag_xyfill(this) result(flag_xyfill)
       class(hist_field_info_t), intent(in) :: this
       logical                              :: flag_xyfill
 
@@ -317,7 +317,7 @@ CONTAINS
 
    !#######################################################################
 
-   function get_fill_value(this) result(fill_value)
+   pure function get_fill_value(this) result(fill_value)
       class(hist_field_info_t), intent(in) :: this
       real(REAL64)                         :: fill_value
 
@@ -327,7 +327,7 @@ CONTAINS
 
    !#######################################################################
 
-   function get_mixing_ratio(this) result(info)
+   pure function get_mixing_ratio(this) result(info)
       class(hist_field_info_t), intent(in) :: this
       character(len=:), allocatable        :: info
 
@@ -336,7 +336,7 @@ CONTAINS
 
    !#######################################################################
 
-   function get_cell_methods(this) result(info)
+   pure function get_cell_methods(this) result(info)
       class(hist_field_info_t), intent(in) :: this
       character(len=:), allocatable        :: info
 


### PR DESCRIPTION
The main purpose of this PR is to add logic to accumulate fields (average, min, max, standard deviation). Side effects of these changes:

1. Logic relies on whether there are fill values, so I added fill_values to the hist_field_info_t object.
2. All accumulation needs to be done with REAL64 or the numbers are off, so took the opportunity to clean up the hist_buffer interfaces to only have real64 buffers (conversion to real32 happens before writing to a file)
3. I added an interface in hist_api.F90 so that the host model doesn't need to know about buffers.

Modified files:
```
M    src/hist_api.F90
- add new hist_field_norm_value interfaces (called by host). These, in turn, call hist_buffer_norm_value
- remove unnecessary interfaces - all buffers are now real64, so the only thing that varies is the dimension

M   src/hist_buffer.F90
- remove unnecessary interfaces - all buffers are now real64
- add accumulation logic for min, max, avg, var (standard deviation)
  - includes addition of new var_buffer for standard deviation calculation
  - also includes check_fill_value that confirms that the fill values are consistently applied across a whole column (all vertical layers); errors otherwise
- change num_samples to be a 1d array - we only need to keep track of samples once per column since fill values are ensured to be consistently applied

M    src/hist_field.F90
- add fillvalue to object; add a getter for fill value
```